### PR TITLE
Kubeconfig save/merge fix.

### DIFF
--- a/utility/kubernetes.go
+++ b/utility/kubernetes.go
@@ -79,16 +79,9 @@ func mergeConfigs(localKubeconfigPath string, k3sconfig []byte, switchContext bo
 	}
 
 	// Remove the temporarily generated file
-	if osResult == "windows" {
-		_, err = exec.Command("powershell", "remove-item", file.Name()).Output()
-		if err != nil {
-			return nil, fmt.Errorf("could not remove temporary kubeconfig file: %s, %s", file.Name(), err)
-		}
-	} else {
-		err = os.Remove(file.Name())
-		if err != nil {
-			return nil, fmt.Errorf("could not remove temporary kubeconfig file: %s, %s", file.Name(), err)
-		}
+	err = os.Remove(file.Name())
+	if err != nil {
+		return nil, fmt.Errorf("could not remove temporary kubeconfig file: %s, %s", file.Name(), err)
 	}
 
 	return data, nil

--- a/utility/kubernetes.go
+++ b/utility/kubernetes.go
@@ -72,6 +72,12 @@ func mergeConfigs(localKubeconfigPath string, k3sconfig []byte, switchContext bo
 		return nil, fmt.Errorf("could not merge kubeconfigs: %s", err)
 	}
 
+	// To be able to remove the file, it aught to be closed.
+	err = file.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not close temporary kubeconfig file: %s, %s", file.Name(), err)
+	}
+
 	// Remove the temporarily generated file
 	if osResult == "windows" {
 		_, err = exec.Command("powershell", "remove-item", file.Name()).Output()
@@ -81,7 +87,7 @@ func mergeConfigs(localKubeconfigPath string, k3sconfig []byte, switchContext bo
 	} else {
 		err = os.Remove(file.Name())
 		if err != nil {
-			return nil, fmt.Errorf("could not remove temporary kubeconfig file: %s", file.Name())
+			return nil, fmt.Errorf("could not remove temporary kubeconfig file: %s, %s", file.Name(), err)
 		}
 	}
 


### PR DESCRIPTION
This is a minor fix to a bug I encounter on windows, I'm unsure if it exists on linux or osx, but it should due to why it breaks on windows!

When the temporary file is to be deleted, it is not yet closed (the close command is deferred and seems to not invoke on delete), so this fix closes the file before the removal command.

I also appended the error in the none-windows remove code (to keep the messages as similar as possible).

---

Edit:

Removed the windows specific file removal snippet too, as the `os.Remove` is OS agnostic and works fine on windows :)