### PR TITLE
Resolve Defect in Civo CLI Custom Output

### DIFF
--- a/utility/output_writer.go
+++ b/utility/output_writer.go
@@ -203,13 +203,15 @@ func (ow *OutputWriter) WriteCustomOutput(fields string) {
 	copy(defaultKeys, ow.Keys)
 	sort.Sort(byLen(ow.Keys))
 
-	//build my custom map
-	customMap := make(map[string]string)
-	for index, key := range defaultKeys {
-		customMap[key] = ow.Values[0][index]
+	// Transcribe Data
+	customMap := make(map[string][]string)
+	for i, key := range defaultKeys {
+		for _, row := range ow.Values {
+			customMap[key] = append(customMap[key], row[i])
+		}
 	}
 
-	for range ow.Values {
+	for i, _ := range ow.Values {
 		output := fields
 		for key, name := range ow.Keys {
 			var re = regexp.MustCompile(fmt.Sprintf(`%s`, name))
@@ -220,7 +222,7 @@ func (ow *OutputWriter) WriteCustomOutput(fields string) {
 
 		for index, name := range ow.Keys {
 			if strings.Contains(output, fmt.Sprintf("$%v$", index)) {
-				output = strings.Replace(output, fmt.Sprintf("$%v$", index), customMap[name], 1)
+				output = strings.Replace(output, fmt.Sprintf("$%v$", index), customMap[name][i], 1)
 			}
 		}
 		output = strings.Replace(output, "\\t", "\t", -1)

--- a/utility/output_writer_test.go
+++ b/utility/output_writer_test.go
@@ -1,0 +1,28 @@
+package utility
+
+import "testing"
+
+func TestWriteCustomOutput(t *testing.T) {
+	ow := NewOutputWriter()
+	ow.StartLine()
+	ow.AppendData("A", "a")
+	ow.AppendData("B", "b")
+	ow.WriteCustomOutput("B")
+}
+
+func ExampleFWriteCustomOutput() {
+	ow := NewOutputWriter()
+	ow.StartLine()
+	ow.AppendData("ID", "1")
+	ow.AppendData("Key", "Raspberry")
+	ow.AppendData("Desc", "first")
+	ow.StartLine()
+	ow.AppendData("ID", "2")
+	ow.AppendData("Key", "Pi")
+	ow.AppendData("Desc", "second")
+	ow.WriteCustomOutput("Key,Desc")
+
+	// Output:
+	// Raspberry,first
+	// Pi,second
+}

--- a/utility/output_writer_test.go
+++ b/utility/output_writer_test.go
@@ -12,6 +12,7 @@ func TestWriteCustomOutput(t *testing.T) {
 
 func ExampleFWriteCustomOutput() {
 	ow := NewOutputWriter()
+	// Write 3 lines and assert correct result
 	ow.StartLine()
 	ow.AppendData("ID", "1")
 	ow.AppendData("Key", "Raspberry")
@@ -20,9 +21,14 @@ func ExampleFWriteCustomOutput() {
 	ow.AppendData("ID", "2")
 	ow.AppendData("Key", "Pi")
 	ow.AppendData("Desc", "second")
+	ow.StartLine()
+	ow.AppendData("ID", "3")
+	ow.AppendData("Key", "Zero")
+	ow.AppendData("Desc", "third")
 	ow.WriteCustomOutput("Key,Desc")
 
 	// Output:
 	// Raspberry,first
 	// Pi,second
+	// Zero,third
 }


### PR DESCRIPTION
**The Custom Output for `civo` cli doesn't handle multiple records, it reprints the same record:**

## Example

```
martyn@macbook-pro civo-cli % civo domain ls -o custom -f ID,Name 
bfa72839-ff6d-42f5-9aef-9d0e81565bd7,apps.martynbristow.co.uk
bfa72839-ff6d-42f5-9aef-9d0e81565bd7,apps.martynbristow.co.uk
bfa72839-ff6d-42f5-9aef-9d0e81565bd7,apps.martynbristow.co.uk
bfa72839-ff6d-42f5-9aef-9d0e81565bd7,apps.martynbristow.co.uk
```

### Expected

```
+--------------------------------------+--------------------------+
| ID                                   | Name                     |
+--------------------------------------+--------------------------+
| bfa72839-ff6d-42f5-9aef-9d0e81565bd7 | apps.martynbristow.co.uk |
| 661ad5c1-7030-4185-a3d9-cf8d5a8b9fd5 | coffeecatscode.co.uk     |
| 9b081910-48f5-403b-8db1-7400ebf7f679 | martynbristow.co.uk      |
| 48a91b8b-023b-4584-b765-a208683fc650 | martyncoding.co.uk       |
+--------------------------------------+--------------------------+
```

## Changes

* Add GoLang Example to test function and protect regression
* Fix issue by transcribing data

### Testing

Using `local` build:

martyn@macbook-pro civo-cli % ./civo domain ls                     
```
+--------------------------------------+--------------------------+
| ID                                   | Name                     |
+--------------------------------------+--------------------------+
| bfa72839-ff6d-42f5-9aef-9d0e81565bd7 | apps.martynbristow.co.uk |
| 661ad5c1-7030-4185-a3d9-cf8d5a8b9fd5 | coffeecatscode.co.uk     |
| 9b081910-48f5-403b-8db1-7400ebf7f679 | martynbristow.co.uk      |
| 48a91b8b-023b-4584-b765-a208683fc650 | martyncoding.co.uk       |
+--------------------------------------+--------------------------+ 
```

```
martyn@macbook-pro civo-cli % ./civo domain ls -o custom -f ID,Name
bfa72839-ff6d-42f5-9aef-9d0e81565bd7,apps.martynbristow.co.uk
661ad5c1-7030-4185-a3d9-cf8d5a8b9fd5,coffeecatscode.co.uk
9b081910-48f5-403b-8db1-7400ebf7f679,martynbristow.co.uk
48a91b8b-023b-4584-b765-a208683fc650,martyncoding.co.uk
```