### PR TITLE
Make install.sh prefer arm64 when compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Civo CLI is a tool to manage your [Civo.com](https://www.civo.com) account from 
 
 Civo CLI is built with Go and distributed as binary files, available for multiple operating systems and downloadable from https://github.com/civo/cli/releases.
 
-### Installing on MAC
+### Installing on macOS
 
 If you have a Mac, you can install it using [Homebrew](https://brew.sh):
 
@@ -51,10 +51,10 @@ $ curl -sL https://civo.com/get | sh
 
 ### Installing on Windows
 
-Civo Cli is available to download on windows via Chocolatey and Scoop
+Civo CLI is available to download on windows via Chocolatey and Scoop
 
 For installing via Chocolatey you need [Chocolatey](https://chocolatey.org/install) package manager installed on your PC.
-- run `choco install civo-cli` and it will install Civo Cli on your PC.
+- run `choco install civo-cli` and it will install Civo CLI on your PC.
 
 For installing via Scoop you need [Scoop](https://scoop.sh/) installed as a package manager, then:
 - add the extras bucket with `scoop bucket add extras`
@@ -73,7 +73,7 @@ cd ..
 cp -r cli ./$HOME
 export PATH="$HOME/cli:$PATH"
 ```
-With this, we have installed the civo cli successfully, check the working by running any of the following commands.
+With this, we have installed the Civo CLI successfully, check the working by running any of the following commands.
 
 **Note:** For the first time when you are running, make sure you set your current region. check ----> [Region](#region)
 

--- a/install.sh
+++ b/install.sh
@@ -62,10 +62,10 @@ setup_verify_arch() {
     SUFFIX=
     ;;
   arm64)
-    ARCH=-arm
+    ARCH=-arm64
     ;;
   aarch64)
-    ARCH=-arm
+    ARCH=-arm64
     ;;
   arm*)
     ARCH=-arm


### PR DESCRIPTION
As the Linux and Darwin arm64 binaries are already released as platform-arm64.tar.gz, I believe install.sh should prefer 64-bit binaries when suitable. AArch64 and arm64 should be identical in practice as this is the same instruction set. This would address incompatibility (#61) when installing on Darwin ARM64 as it is 64-bit only. Linux ARM64 would receive 64-bit binaries after this change. (This change has not been tested on Linux AMD64 however.)

I also made some minor fixes to README formatting for macOS and normalized the usage of "Civo CLI" in OS instructions to match initial mentions.