### PR TITLE
Fix typo in default config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -105,7 +105,7 @@ func SaveConfig() {
 
 func checkConfigFile(filename string) error {
 	file, err := os.Stat(filename)
-	fileContend := []byte(fmt.Sprintf("{\"apikeys\":{},\"meta\":{\"admin\":false,\"current_apikey\":\"\",\"default_region\":\"SGV1\",\"latest_release_check\":\"%s\",\"url\":\"https://api.civo.com\"}}", time.Now().Format(time.RFC3339)))
+	fileContend := []byte(fmt.Sprintf("{\"apikeys\":{},\"meta\":{\"admin\":false,\"current_apikey\":\"\",\"default_region\":\"SVG1\",\"latest_release_check\":\"%s\",\"url\":\"https://api.civo.com\"}}", time.Now().Format(time.RFC3339)))
 	if os.IsNotExist(err) {
 		_, err := os.Create(filename)
 		if err != nil {


### PR DESCRIPTION
The default region in the config file is set to SGV1 on first launch, but the actual region is called SVG1.

This might be the reason for the cryptic error in #67