### PR TITLE
Fix default region

### DIFF
--- a/cmd/apikey_save.go
+++ b/cmd/apikey_save.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/utility"
@@ -16,6 +17,21 @@ var apikeySaveCmd = &cobra.Command{
 	Example: "civo apikey save NAME KEY",
 	Run: func(cmd *cobra.Command, args []string) {
 		config.Current.APIKeys[args[0]] = args[1]
+
+		if config.Current.Meta.DefaultRegion == "" {
+			client, err := config.CivoAPIClient()
+			if err != nil {
+				utility.Error("Unable to create a Civo API client, please report this at https://github.com/civo/cli")
+				os.Exit(1)
+			}
+			region, err := client.GetDefaultRegion()
+			if err != nil {
+				utility.Error("Unable to get the default regions from the Civo API")
+				os.Exit(1)
+			}
+			config.Current.Meta.DefaultRegion = region.Code
+		}
+
 		config.SaveConfig()
 
 		if len(config.Current.APIKeys) == 1 {

--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -40,5 +40,4 @@ func init() {
 	firewallRuleCreateCmd.Flags().StringArrayVarP(&cidr, "cidr", "c", []string{}, "the CIDR of the rule you can use (e.g. -c 10.10.10.1/32, 10.10.10.2/32)")
 	firewallRuleCreateCmd.Flags().StringVarP(&direction, "direction", "d", "", "the direction of the rule need to be ingress")
 	firewallRuleCreateCmd.Flags().StringVarP(&label, "label", "l", "", "a string that will be the displayed as the name/reference for this rule")
-
 }

--- a/cmd/firewall_create.go
+++ b/cmd/firewall_create.go
@@ -20,6 +20,8 @@ var firewallCreateCmd = &cobra.Command{
 	Example: "civo firewall create NAME",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/firewall_create.go
+++ b/cmd/firewall_create.go
@@ -11,7 +11,7 @@ import (
 )
 
 var firewallnetwork string
-var defautlNetwork *civogo.Network
+var defaultNetwork *civogo.Network
 
 var firewallCreateCmd = &cobra.Command{
 	Use:     "create",
@@ -30,20 +30,20 @@ var firewallCreateCmd = &cobra.Command{
 		}
 
 		if firewallnetwork == "default" {
-			defautlNetwork, err = client.GetDefaultNetwork()
+			defaultNetwork, err = client.GetDefaultNetwork()
 			if err != nil {
 				utility.Error("%s", err)
 				os.Exit(1)
 			}
 		} else {
-			defautlNetwork, err = client.FindNetwork(firewallnetwork)
+			defaultNetwork, err = client.FindNetwork(firewallnetwork)
 			if err != nil {
 				utility.Error("%s", err)
 				os.Exit(1)
 			}
 		}
 
-		firewall, err := client.NewFirewall(args[0], defautlNetwork.ID)
+		firewall, err := client.NewFirewall(args[0], defaultNetwork.ID)
 		if err != nil {
 			utility.Error("%s", err)
 			os.Exit(1)

--- a/cmd/firewall_list.go
+++ b/cmd/firewall_list.go
@@ -25,6 +25,8 @@ If you wish to use a custom format, the available fields are:
 
 Example: civo firewall ls -o custom -f "ID: Name"`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/firewall_remove.go
+++ b/cmd/firewall_remove.go
@@ -23,6 +23,8 @@ var firewallRemoveCmd = &cobra.Command{
 	Short:   "Remove a firewall",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/firewall_rule_create.go
+++ b/cmd/firewall_rule_create.go
@@ -23,6 +23,8 @@ var firewallRuleCreateCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	Example: "civo firewall rule create FIREWALL_NAME/FIREWALL_ID [flags]",
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/firewall_rule_list.go
+++ b/cmd/firewall_rule_list.go
@@ -29,6 +29,8 @@ If you wish to use a custom format, the available fields are:
 
 Example: civo firewall rule ls FIREWALL_NAME -o custom -f "ID: Label"`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/firewall_rule_remove.go
+++ b/cmd/firewall_rule_remove.go
@@ -23,6 +23,8 @@ var firewallRuleRemoveCmd = &cobra.Command{
 	Short:   "Remove firewall rule",
 	Example: "civo firewall rule remove FIREWALL_NAME/FIREWALL_ID FIREWALL_RULE_ID",
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/firewall_update.go
+++ b/cmd/firewall_update.go
@@ -17,6 +17,8 @@ var firewallUpdateCmd = &cobra.Command{
 	Example: "civo firewall update OLD_NAME NEW_NAME",
 	Args:    cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_console.go
+++ b/cmd/instance_console.go
@@ -24,6 +24,8 @@ If you wish to use a custom format, the available fields are:
 
 Example: civo instance console ID/NAME`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -49,6 +49,7 @@ If you wish to use a custom format, the available fields are:
 	* Script
 	* CreatedAt`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
 
 		check, region, err := utility.CheckAvailability("iaas", regionSet)
 		if err != nil {

--- a/cmd/instance_firewall.go
+++ b/cmd/instance_firewall.go
@@ -23,6 +23,8 @@ If you wish to use a custom format, the available fields are:
 	* Hostname
 	* FirewallID`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		if len(args) != 2 {
 			fmt.Printf("You must specify %s parameters (you gave %s), the ID/name and the firewall ID\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
 			os.Exit(1)

--- a/cmd/instance_ip.go
+++ b/cmd/instance_ip.go
@@ -14,15 +14,21 @@ var instancePublicIPCmd = &cobra.Command{
 	Use:     "public-ip",
 	Example: "civo instance public-ip ID/HOSTNAME",
 	Args:    cobra.MinimumNArgs(1),
-	Short:   "Show instance's public IP",
+	Short:   "Show instance's public IP [deprectated]",
 	Aliases: []string{"ip", "publicip"},
 	Long: `Show the specified instance's public IP by part of the instance's ID or name.
 If you wish to use a custom format, the available fields are:
 
 	* ID
 	* Hostname
-	* PublicIP`,
+	* PublicIP
+
+This command is deprecated and instead you should use:
+
+civo instance show ID/HOSTNAME -o custom -f "PublicIP"`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_list.go
+++ b/cmd/instance_list.go
@@ -45,6 +45,8 @@ If you wish to use a custom format, the available fields are:
 	* Script
 	* CreatedAt`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_move_ip.go
+++ b/cmd/instance_move_ip.go
@@ -24,6 +24,8 @@ If you wish to use a custom format, the available fields are:
 	* Hostname
 	* PublicIP`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		if len(args) != 2 {
 			fmt.Printf("You must specify %s parameters (you gave %s), the ID/name and the public IP\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
 			os.Exit(1)

--- a/cmd/instance_password.go
+++ b/cmd/instance_password.go
@@ -23,6 +23,8 @@ If you wish to use a custom format, the available fields are:
 	* Password
 	* User`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_reboot.go
+++ b/cmd/instance_reboot.go
@@ -21,6 +21,8 @@ If you wish to use a custom format, the available fields are:
 	* ID
 	* Hostname`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_remove.go
+++ b/cmd/instance_remove.go
@@ -28,6 +28,8 @@ If you wish to use a custom format, the available fields are:
 	* ID
 	* Hostname`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_show.go
+++ b/cmd/instance_show.go
@@ -49,6 +49,8 @@ If you wish to use a custom format, the available fields are:
 	* Script
 	* CreatedAt`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_size.go
+++ b/cmd/instance_size.go
@@ -18,6 +18,8 @@ var instanceSizeCmd = &cobra.Command{
 	Short:   "List instances size",
 	Long:    `List all current instances size.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_soft_reboot.go
+++ b/cmd/instance_soft_reboot.go
@@ -21,6 +21,8 @@ If you wish to use a custom format, the available fields are:
 	* ID
 	* Hostname`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_start.go
+++ b/cmd/instance_start.go
@@ -22,6 +22,8 @@ If you wish to use a custom format, the available fields are:
 	* ID
 	* Hostname`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_stop.go
+++ b/cmd/instance_stop.go
@@ -24,6 +24,8 @@ If you wish to use a custom format, the available fields are:
 	* ID
 	* Hostname`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_tag.go
+++ b/cmd/instance_tag.go
@@ -24,6 +24,8 @@ If you wish to use a custom format, the available fields are:
 	* Hostname
 	* Tags`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_update.go
+++ b/cmd/instance_update.go
@@ -26,6 +26,8 @@ If you wish to use a custom format, the available fields are:
 	* ReverseDNS
 	* Notes`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/instance_upgrade.go
+++ b/cmd/instance_upgrade.go
@@ -26,6 +26,8 @@ If you wish to use a custom format, the available fields are:
 	* OldSize
 	* NewSize`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		if len(args) != 2 {
 			fmt.Printf("You must specify %s parameters (you gave %s), the ID/name and the new size\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
 			os.Exit(1)

--- a/cmd/kubernetes_ recycle.go
+++ b/cmd/kubernetes_ recycle.go
@@ -23,6 +23,8 @@ var kubernetesRecycleCmd = &cobra.Command{
 		return getKubernetesClusterName(toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_app_add.go
+++ b/cmd/kubernetes_app_add.go
@@ -19,6 +19,8 @@ var kubernetesAppAddCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	Short:   "Add the marketplace application to a Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_app_list.go
+++ b/cmd/kubernetes_app_list.go
@@ -22,6 +22,8 @@ If you wish to use a custom format, the available fields are:
 	* Plans
 	* Dependencies`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)

--- a/cmd/kubernetes_app_show.go
+++ b/cmd/kubernetes_app_show.go
@@ -26,6 +26,8 @@ var kubernetesAppShowCmd = &cobra.Command{
 	// 	return getKubernetesList(toComplete), cobra.ShellCompDirectiveNoFileComp
 	// },
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_config.go
+++ b/cmd/kubernetes_config.go
@@ -24,6 +24,8 @@ If you wish to use a custom format, the available fields are:
 
 	* KubeConfig`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_create.go
+++ b/cmd/kubernetes_create.go
@@ -25,6 +25,7 @@ var kubernetesCreateCmd = &cobra.Command{
 	Example: "civo kubernetes create CLUSTER_NAME [flags]",
 	Short:   "Create a new Kubernetes cluster",
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
 
 		check, region, err := utility.CheckAvailability("kubernetes", regionSet)
 		if err != nil {

--- a/cmd/kubernetes_list.go
+++ b/cmd/kubernetes_list.go
@@ -25,6 +25,8 @@ If you wish to use a custom format, the available fields are:
 	* Pools
 	* Status`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 
 		if regionSet != "" {

--- a/cmd/kubernetes_list_version.go
+++ b/cmd/kubernetes_list_version.go
@@ -22,6 +22,8 @@ If you wish to use a custom format, the available fields are:
 	* Type
 	* Default`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_nodepool_create.go
+++ b/cmd/kubernetes_nodepool_create.go
@@ -27,6 +27,8 @@ var kubernetesNodePoolCreateCmd = &cobra.Command{
 		return getKubernetesList(toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes_nodepool_delete.go
@@ -26,6 +26,8 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 		return getKubernetesList(toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_nodepool_scale.go
+++ b/cmd/kubernetes_nodepool_scale.go
@@ -25,6 +25,8 @@ var kubernetesNodePoolScaleCmd = &cobra.Command{
 		return getKubernetesList(toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_remove.go
+++ b/cmd/kubernetes_remove.go
@@ -27,6 +27,8 @@ var kubernetesRemoveCmd = &cobra.Command{
 		return getKubernetesList(toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_rename.go
+++ b/cmd/kubernetes_rename.go
@@ -18,6 +18,8 @@ var kubernetesRenameCmd = &cobra.Command{
 	Example: "civo kubernetes rename OLD_CLUSTER_NAME --name NEW_CLUSTER_NAME",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_show.go
+++ b/cmd/kubernetes_show.go
@@ -40,6 +40,8 @@ If you wish to use a custom format, the available fields are:
 		return getKubernetesList(toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_size.go
+++ b/cmd/kubernetes_size.go
@@ -18,6 +18,8 @@ var kubernetesSizeCmd = &cobra.Command{
 	Short:   "List kubernetes size",
 	Long:    `List all current kubernetes size.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/kubernetes_upgrade.go
+++ b/cmd/kubernetes_upgrade.go
@@ -19,6 +19,8 @@ var kubernetesUpgradeCmd = &cobra.Command{
 	Short:   "Upgrade/rescale a Kubernetes cluster",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/network_create.go
+++ b/cmd/network_create.go
@@ -16,6 +16,8 @@ var networkCreateCmd = &cobra.Command{
 	Short:   "Create a new network",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/network_list.go
+++ b/cmd/network_list.go
@@ -22,6 +22,8 @@ If you wish to use a custom format, the available fields are:
 	* CIDR
 	* Default`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/network_remove.go
+++ b/cmd/network_remove.go
@@ -21,6 +21,8 @@ var networkRemoveCmd = &cobra.Command{
 	Short:   "Remove a network",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/network_update.go
+++ b/cmd/network_update.go
@@ -16,6 +16,8 @@ var networkUpdateCmd = &cobra.Command{
 	Short:   "Rename a network",
 	Args:    cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/civo/cli/config"
-	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
 )
 
@@ -52,8 +51,4 @@ func init() {
 
 	// Add warning if the region is empty, for the user with the old config
 	config.ReadConfig()
-	if config.Current.Meta.DefaultRegion == "" {
-		utility.Warning("No region set - using the default one - set a default using \"civo region current REGION\" or specify one with every command using \"--region=REGION\"")
-	}
-
 }

--- a/cmd/snapshot_create.go
+++ b/cmd/snapshot_create.go
@@ -19,6 +19,8 @@ var snapshotCreateCmd = &cobra.Command{
 	Short:   "Create a new snapshot",
 	Args:    cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/snapshot_list.go
+++ b/cmd/snapshot_list.go
@@ -34,6 +34,8 @@ If you wish to use a custom format, the available fields are:
 
 Example: civo snapshot ls -o custom -f "ID: Name (Hostname)"`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/snapshot_remove.go
+++ b/cmd/snapshot_remove.go
@@ -18,6 +18,8 @@ var snapshotRemoveCmd = &cobra.Command{
 	Short:   "Remove/delete a snapshot",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/volume_attach.go
+++ b/cmd/volume_attach.go
@@ -20,6 +20,8 @@ var volumeAttachCmd = &cobra.Command{
 	Short:   "Attach a volume to an instance",
 	Args:    cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/volume_create.go
+++ b/cmd/volume_create.go
@@ -21,6 +21,8 @@ var volumeCreateCmd = &cobra.Command{
 	Short:   "Create a new volume",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/volume_detach.go
+++ b/cmd/volume_detach.go
@@ -20,6 +20,8 @@ var volumeDetachCmd = &cobra.Command{
 	Short:   "Detach a volume from an instance",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/volume_list.go
+++ b/cmd/volume_list.go
@@ -29,6 +29,8 @@ If you wish to use a custom format, the available fields are:
 
 Example: civo volume ls -o custom -f "ID: Name (SizeGigabytes)`,
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/volume_remove.go
+++ b/cmd/volume_remove.go
@@ -18,6 +18,8 @@ var volumeRemoveCmd = &cobra.Command{
 	Short:   "Remove a volume",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/cmd/volume_resize.go
+++ b/cmd/volume_resize.go
@@ -18,6 +18,8 @@ var volumeResizeCmd = &cobra.Command{
 	Example: "civo volume resize VOLUME_NAME --size-gb=100",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if regionSet != "" {
 			client.Region = regionSet

--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,6 @@ func ReadConfig() {
 }
 
 func loadConfig(filename string) {
-
 	var err error
 	err = checkConfigFile(filename)
 	if err != nil {
@@ -105,7 +104,7 @@ func SaveConfig() {
 
 func checkConfigFile(filename string) error {
 	file, err := os.Stat(filename)
-	fileContend := []byte(fmt.Sprintf("{\"apikeys\":{},\"meta\":{\"admin\":false,\"current_apikey\":\"\",\"default_region\":\"SVG1\",\"latest_release_check\":\"%s\",\"url\":\"https://api.civo.com\"}}", time.Now().Format(time.RFC3339)))
+	fileContend := []byte(fmt.Sprintf("{\"apikeys\":{},\"meta\":{\"admin\":false,\"current_apikey\":\"\",\"latest_release_check\":\"%s\",\"url\":\"https://api.civo.com\"}}", time.Now().Format(time.RFC3339)))
 	if os.IsNotExist(err) {
 		_, err := os.Create(filename)
 		if err != nil {

--- a/utility/check.go
+++ b/utility/check.go
@@ -3,6 +3,7 @@ package utility
 import (
 	"fmt"
 	"math"
+	"os"
 	"runtime"
 	"strings"
 
@@ -30,7 +31,6 @@ func CheckOS() string {
 
 // CheckQuotaPercent function to check the percent of the quota
 func CheckQuotaPercent(limit int, usage int) string {
-
 	var returnText string
 
 	calculation := float64(usage) / float64(limit) * 100
@@ -50,7 +50,6 @@ func CheckQuotaPercent(limit int, usage int) string {
 
 // GetK3sSize is a functon to return only the k3s size
 func GetK3sSize() ([]string, error) {
-
 	client, err := config.CivoAPIClient()
 	if err != nil {
 		return nil, err
@@ -73,7 +72,6 @@ func GetK3sSize() ([]string, error) {
 
 // CheckAPPName is a function to check if the app name is valid
 func CheckAPPName(appName string) bool {
-
 	client, err := config.CivoAPIClient()
 	if err != nil {
 		return false
@@ -136,4 +134,12 @@ func CheckAvailability(resource string, regionSet string) (bool, string, error) 
 	}
 
 	return false, defaultRegion.Code, nil
+}
+
+// EnsureCurrentRegion there's a current region set, error out if not
+func EnsureCurrentRegion() {
+	if config.Current.Meta.DefaultRegion == "" {
+		Error("No region set - list available regions with \"civo region ls\" and choose a default using \"civo region current REGION\", or specify one with every command using \"--region=REGION\"\n")
+		os.Exit(1)
+	}
 }

--- a/utility/color_util.go
+++ b/utility/color_util.go
@@ -46,7 +46,6 @@ func Red(value string) string {
 // Error is the function to handler all error in the Cli
 func Error(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "%s: %s\n", color.Red.Sprintf("Error"), fmt.Sprintf(msg, args...))
-
 }
 
 // Warning is the function to handler all error in the Cli


### PR DESCRIPTION
We're getting comments from our users, because the `default_region` is hardcoded in the CLI to use SVG1, which any new customers cannot see/use.

The main changes in this PR are to remove the default_region when creating a new config file completely. Then only check if one is set on methods that require a region. And finally to pull down the default region when adding an API key if one isn't set. 

![image_from_ios](https://user-images.githubusercontent.com/22904/117638898-40221000-b17b-11eb-9642-e36f210ce8eb.jpg)
