### PR TITLE
Only show stable k3s versions

### DIFF
--- a/cmd/kubernetes_list_version.go
+++ b/cmd/kubernetes_list_version.go
@@ -41,6 +41,10 @@ If you wish to use a custom format, the available fields are:
 
 		ow := utility.NewOutputWriter()
 		for _, version := range kubeVersions {
+			if version.Type != "stable" {
+				continue
+			}
+
 			ow.StartLine()
 
 			ow.AppendDataWithLabel("version", version.Version, "Version")

--- a/cmd/kubernetes_list_version.go
+++ b/cmd/kubernetes_list_version.go
@@ -41,7 +41,7 @@ If you wish to use a custom format, the available fields are:
 
 		ow := utility.NewOutputWriter()
 		for _, version := range kubeVersions {
-			if version.Type != "stable" {
+			if version.Type == "deprecated" {
 				continue
 			}
 


### PR DESCRIPTION
Closes #109

New output:

```
$ civo kubernetes versions
+-------------+--------+---------+
| Version     | Type   | Default |
+-------------+--------+---------+
| 1.20.0+k3s1 | stable | true    |
+-------------+--------+---------+


$ civo k8s versions
+-------------+--------+---------+
| Version     | Type   | Default |
+-------------+--------+---------+
| 1.20.0+k3s1 | stable | true    |
+-------------+--------+---------+


$ civo k3s versions
+-------------+--------+---------+
| Version     | Type   | Default |
+-------------+--------+---------+
| 1.20.0+k3s1 | stable | true    |
+-------------+--------+---------+
```