### PR TITLE
Add support for using an existing firewall or create a new one when creating Kubernetes cluster

### DIFF
--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var defaultK8sClusterFirewallRules = "80,443,6443"
+
 var kubernetesCmd = &cobra.Command{
 	Use:     "kubernetes",
 	Aliases: []string{"k3s", "k8s", "kube"},
@@ -83,6 +85,8 @@ func init() {
 	kubernetesCreateCmd.Flags().BoolVarP(&saveConfigKubernetes, "save", "", false, "save the config")
 	kubernetesCreateCmd.Flags().BoolVarP(&mergeConfigKubernetes, "merge", "m", false, "merge the config with existing kubeconfig if it already exists.")
 	kubernetesCreateCmd.Flags().BoolVarP(&switchConfigKubernetes, "switch", "", false, "switch context to newly-created cluster")
+	kubernetesCreateCmd.Flags().StringVarP(&existingFirewall, "existing-firewall", "e", "", "optional, ID of existing firewall to use")
+	kubernetesCreateCmd.Flags().StringVarP(&createFirewall, "create-firewall", "c", defaultK8sClusterFirewallRules, "optional, comma-separated list of ports to open (leave blank for default or you can use \"all\")")
 
 	kubernetesRenameCmd.Flags().StringVarP(&kubernetesNewName, "name", "n", "", "the new name for the cluster.")
 
@@ -111,7 +115,6 @@ func init() {
 	kubernetesNodePoolCmd.AddCommand(kubernetesNodePoolScaleCmd)
 	kubernetesNodePoolScaleCmd.Flags().IntVarP(&numTargetNodesPoolScale, "nodes", "n", 3, "the number of nodes to scale for the pool.")
 	kubernetesNodePoolScaleCmd.MarkFlagRequired("nodes")
-
 
 }
 

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -10,8 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var defaultK8sClusterFirewallRules = "80,443,6443"
-
 var kubernetesCmd = &cobra.Command{
 	Use:     "kubernetes",
 	Aliases: []string{"k3s", "k8s", "kube"},
@@ -86,7 +84,7 @@ func init() {
 	kubernetesCreateCmd.Flags().BoolVarP(&mergeConfigKubernetes, "merge", "m", false, "merge the config with existing kubeconfig if it already exists.")
 	kubernetesCreateCmd.Flags().BoolVarP(&switchConfigKubernetes, "switch", "", false, "switch context to newly-created cluster")
 	kubernetesCreateCmd.Flags().StringVarP(&existingFirewall, "existing-firewall", "e", "", "optional, ID of existing firewall to use")
-	kubernetesCreateCmd.Flags().StringVarP(&createFirewall, "create-firewall", "c", defaultK8sClusterFirewallRules, "optional, comma-separated list of ports to open (leave blank for default or you can use \"all\")")
+	kubernetesCreateCmd.Flags().StringVarP(&createFirewall, "create-firewall", "c", "", "optional, comma-separated list of ports to open - leave blank for default (80,443,6443) or you can use \"all\"")
 
 	kubernetesRenameCmd.Flags().StringVarP(&kubernetesNewName, "name", "n", "", "the new name for the cluster.")
 

--- a/cmd/kubernetes_create.go
+++ b/cmd/kubernetes_create.go
@@ -110,15 +110,21 @@ var kubernetesCreateCmd = &cobra.Command{
 			NetworkID:       network.ID,
 		}
 
+		if createFirewall == "" {
+			configKubernetes.FirewallRule = "80,443,6443"
+		} else {
+			configKubernetes.FirewallRule = createFirewall
+		}
+
 		if existingFirewall != "" {
-			if createFirewall != defaultK8sClusterFirewallRules {
+			if createFirewall != "" {
 				utility.Error("You can't use --create-firewall together with --existing-firewall flag")
 				os.Exit(1)
 			}
 
 			ef, err := client.FindFirewall(existingFirewall)
 			if err != nil {
-				utility.Error("Unable to find existing %q firewall - %s", existingFirewall, err)
+				utility.Error("Unable to find %q firewall - %s", existingFirewall, err)
 				os.Exit(1)
 			}
 
@@ -128,11 +134,7 @@ var kubernetesCreateCmd = &cobra.Command{
 			}
 
 			configKubernetes.InstanceFirewall = ef.ID
-			createFirewall = ""
-		}
-
-		if createFirewall != "" {
-			configKubernetes.FirewallRule = createFirewall
+			configKubernetes.FirewallRule = ""
 		}
 
 		if kubernetesVersion != "latest" {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8 // indirect
 	github.com/briandowns/spinner v1.11.1
 	github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c // indirect
-	github.com/civo/civogo v0.2.51
+	github.com/civo/civogo v0.2.52
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect
 	github.com/google/go-querystring v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c/go.mod h1:Ie6SubJv
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/civo/civogo v0.2.51 h1:XZj7K5vNDzq8B732VWt43nOZauReoOAwkTlOEabS/Ek=
 github.com/civo/civogo v0.2.51/go.mod h1:SR0ZOhABfQHjgNQE3UyfX4gaYsrfslkPFRFMx5P29rg=
+github.com/civo/civogo v0.2.52 h1:oeMmeGuJOZFJ+uruu13ywCWOxSa2+Lyk+ePc6rxC8gY=
+github.com/civo/civogo v0.2.52/go.mod h1:SR0ZOhABfQHjgNQE3UyfX4gaYsrfslkPFRFMx5P29rg=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
Close https://github.com/civo/cli/issues/125. Depends on https://github.com/civo/civogo/pull/60.