### PR TITLE
Fix issue when creating firewall rule (due to empty `--protocol`)

### DIFF
--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -51,7 +51,7 @@ func init() {
 	firewallRuleCreateCmd.Flags().StringVarP(&protocol, "protocol", "p", "TCP", "the protocol choice (TCP, UDP, ICMP)")
 	firewallRuleCreateCmd.Flags().StringVarP(&startPort, "startport", "s", "", "the start port of the rule")
 	firewallRuleCreateCmd.Flags().StringVarP(&endPort, "endport", "e", "", "the end port of the rule")
-	firewallRuleCreateCmd.Flags().StringVarP(&cidr, "cidr", "c", "0.0.0.0/0", "the CIDR of the rule you can use (e.g. -c 10.10.10.1/32)")
+	firewallRuleCreateCmd.Flags().StringVarP(&cidr, "cidr", "c", "0.0.0.0/0", "the CIDR of the rule you can use (e.g. -c 10.10.10.1/32,148.2.6.120/32)")
 	firewallRuleCreateCmd.Flags().StringVarP(&direction, "direction", "d", "ingress", "the direction of the rule (only 'ingress' is supported now)")
 	firewallRuleCreateCmd.Flags().StringVarP(&label, "label", "l", "", "a string that will be the displayed as the name/reference for this rule")
 	firewallRuleCreateCmd.MarkFlagRequired("startport")

--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -47,13 +47,12 @@ func init() {
 	firewallRuleCmd.AddCommand(firewallRuleCreateCmd)
 	firewallRuleCmd.AddCommand(firewallRuleRemoveCmd)
 
-	/*
-		Flags for firewall rule create cmd
-	*/
-	firewallRuleCreateCmd.Flags().StringVarP(&protocol, "protocol", "p", "", "the protocol choice (from: TCP, UDP, ICMP)")
+	// Flags for firewall rule create cmd
+	firewallRuleCreateCmd.Flags().StringVarP(&protocol, "protocol", "p", "TCP", "the protocol choice (TCP, UDP, ICMP)")
 	firewallRuleCreateCmd.Flags().StringVarP(&startPort, "startport", "s", "", "the start port of the rule")
 	firewallRuleCreateCmd.Flags().StringVarP(&endPort, "endport", "e", "", "the end port of the rule")
-	firewallRuleCreateCmd.Flags().StringArrayVarP(&cidr, "cidr", "c", []string{}, "the CIDR of the rule you can use (e.g. -c 10.10.10.1/32, 10.10.10.2/32)")
+	firewallRuleCreateCmd.Flags().StringVarP(&cidr, "cidr", "c", "0.0.0.0/0", "the CIDR of the rule you can use (e.g. -c 10.10.10.1/32)")
 	firewallRuleCreateCmd.Flags().StringVarP(&direction, "direction", "d", "ingress", "the direction of the rule (only 'ingress' is supported now)")
 	firewallRuleCreateCmd.Flags().StringVarP(&label, "label", "l", "", "a string that will be the displayed as the name/reference for this rule")
+	firewallRuleCreateCmd.MarkFlagRequired("startport")
 }

--- a/cmd/firewall.go
+++ b/cmd/firewall.go
@@ -54,6 +54,6 @@ func init() {
 	firewallRuleCreateCmd.Flags().StringVarP(&startPort, "startport", "s", "", "the start port of the rule")
 	firewallRuleCreateCmd.Flags().StringVarP(&endPort, "endport", "e", "", "the end port of the rule")
 	firewallRuleCreateCmd.Flags().StringArrayVarP(&cidr, "cidr", "c", []string{}, "the CIDR of the rule you can use (e.g. -c 10.10.10.1/32, 10.10.10.2/32)")
-	firewallRuleCreateCmd.Flags().StringVarP(&direction, "direction", "d", "", "the direction of the rule need to be ingress")
+	firewallRuleCreateCmd.Flags().StringVarP(&direction, "direction", "d", "ingress", "the direction of the rule (only 'ingress' is supported now)")
 	firewallRuleCreateCmd.Flags().StringVarP(&label, "label", "l", "", "a string that will be the displayed as the name/reference for this rule")
 }

--- a/cmd/firewall_rule_create.go
+++ b/cmd/firewall_rule_create.go
@@ -13,8 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var protocol, startPort, endPort, direction, label string
-var cidr []string
+var protocol, startPort, endPort, direction, label, cidr string
 
 var firewallRuleCreateCmd = &cobra.Command{
 	Use:     "create",
@@ -44,7 +43,7 @@ var firewallRuleCreateCmd = &cobra.Command{
 			FirewallID: firewall.ID,
 			Protocol:   protocol,
 			StartPort:  startPort,
-			Cidr:       cidr,
+			Cidr:       strings.Split(cidr, ","),
 			Label:      label,
 		}
 
@@ -80,10 +79,18 @@ var firewallRuleCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(outputFields)
 		default:
-			if newRuleConfig.EndPort == newRuleConfig.StartPort {
-				fmt.Printf("Created a firewall rule called %s allowing access to port %s from %s with ID %s\n", utility.Green(rule.Label), utility.Green(newRuleConfig.StartPort), utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+			if rule.Label == "" {
+				if newRuleConfig.EndPort == newRuleConfig.StartPort {
+					fmt.Printf("Created a firewall rule allowing access to port %s from %s with ID %s\n", utility.Green(newRuleConfig.StartPort), utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+				} else {
+					fmt.Printf("Created a firewall rule allowing access to ports %s-%s from %s with ID %s\n", utility.Green(newRuleConfig.StartPort), utility.Green(newRuleConfig.EndPort), utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+				}
 			} else {
-				fmt.Printf("Created a firewall rule called %s allowing access to ports %s-%s from %s with ID %s\n", utility.Green(rule.Label), utility.Green(newRuleConfig.StartPort), utility.Green(newRuleConfig.EndPort), utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+				if newRuleConfig.EndPort == newRuleConfig.StartPort {
+					fmt.Printf("Created a firewall rule called %s allowing access to port %s from %s with ID %s\n", utility.Green(rule.Label), utility.Green(newRuleConfig.StartPort), utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+				} else {
+					fmt.Printf("Created a firewall rule called %s allowing access to ports %s-%s from %s with ID %s\n", utility.Green(rule.Label), utility.Green(newRuleConfig.StartPort), utility.Green(newRuleConfig.EndPort), utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+				}
 			}
 		}
 	},

--- a/cmd/firewall_rule_create.go
+++ b/cmd/firewall_rule_create.go
@@ -52,8 +52,11 @@ var firewallRuleCreateCmd = &cobra.Command{
 		// from (inbound or outbound) then we will generate an error
 		if direction == "ingress" {
 			newRuleConfig.Direction = direction
+		} else if direction == "" {
+			utility.Error("'--direction' flag can't be empty")
+			os.Exit(1)
 		} else {
-			utility.Error("Sorry but the direccion of the rule must be ingress, not %s", direction)
+			utility.Error("'--direction' flag only support 'ingress' as of now, not '%s'", direction)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Another related fixes:

- Added defaults to `--cidr` and `--direction` flags
- Make `--startport` flag required
- Change `cidr` type from slice of strings to just string so Cobra can print the `default:` text properly in the help message
- Display an error when `--direction` flag is set but empty
- Reword error messages for `--direction` flag
- Added post-create messages for firewall rules without label

Close #139