### PR TITLE
Clarify language and grammar in a few parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ You can remove a particular DNS record from a domain you own by requesting `civo
 
 ```sh
 $ civo domain record remove 4e181dde-bde8-4744-8984-067f957a7d59
-The domain record called www with ID 4e181dde-bde8-4744-8984-067f957a7d59 was delete
+The domain record called www with ID 4e181dde-bde8-4744-8984-067f957a7d59 was deleted
 ```
 
 ## Firewalls
@@ -791,6 +791,7 @@ Options:
 ```
 
 Example usage:
+
 ```sh
 $ civo firewall rule create civocli_demo --startport=22 --direction=ingress --label='SSH access for CLI demo'
  New rule SSH access for CLI demo created

--- a/cmd/apikey_current.go
+++ b/cmd/apikey_current.go
@@ -17,7 +17,7 @@ var apikeyCurrentCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		index, err := apiKeyFind(args[0])
 		if err != nil {
-			utility.Error("Unable find the api key %s", err.Error())
+			utility.Error("Unable find the API key %s", err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/apikey_remove.go
+++ b/cmd/apikey_remove.go
@@ -18,7 +18,7 @@ var apikeyRemoveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		index, err := apiKeyFind(args[0])
 		if err != nil {
-			utility.Error("Unable find the api key %s", err.Error())
+			utility.Error("Unable find the API key %s", err.Error())
 			os.Exit(1)
 		}
 

--- a/cmd/instance_create.go
+++ b/cmd/instance_create.go
@@ -229,7 +229,7 @@ If you wish to use a custom format, the available fields are:
 			ow.AppendDataWithLabel("network_id", resp.NetworkID, "Network ID")
 			ow.AppendDataWithLabel("diskimage_id", resp.SourceID, "Disk image ID")
 			ow.AppendDataWithLabel("initial_user", resp.InitialUser, "Initial User")
-			ow.AppendDataWithLabel("ssh_key", resp.SSHKey, "SSHKey")
+			ow.AppendDataWithLabel("ssh_key", resp.SSHKey, "SSH Key")
 			ow.AppendDataWithLabel("notes", resp.Notes, "Notes")
 			ow.AppendDataWithLabel("firewall_id", resp.FirewallID, "Firewall ID")
 			ow.AppendDataWithLabel("tags", strings.Join(resp.Tags, " "), "Tags")

--- a/cmd/kubernetes_rename.go
+++ b/cmd/kubernetes_rename.go
@@ -53,7 +53,7 @@ var kubernetesRenameCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(outputFields)
 		default:
-			fmt.Printf("The kubernetes cluster was rename to %s with ID %s\n", utility.Green(kubernetesCluster.Name), utility.Green(kubernetesCluster.ID))
+			fmt.Printf("The kubernetes cluster with ID %s was renamed to %s\n", utility.Green(kubernetesCluster.ID), utility.Green(kubernetesCluster.Name))
 		}
 	},
 }


### PR DESCRIPTION
Fixes grammar in cluster renaming confirmation messages, instance creation, and readme (1 section).

Ensures API is capitalised in user messages in `apikey` commands.