### PR TITLE
Change firewall rule separator from comma to semicolon in `civo k8s create` command

### DIFF
--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -84,7 +84,7 @@ func init() {
 	kubernetesCreateCmd.Flags().BoolVarP(&mergeConfigKubernetes, "merge", "m", false, "merge the config with existing kubeconfig if it already exists.")
 	kubernetesCreateCmd.Flags().BoolVarP(&switchConfigKubernetes, "switch", "", false, "switch context to newly-created cluster")
 	kubernetesCreateCmd.Flags().StringVarP(&existingFirewall, "existing-firewall", "e", "", "optional, ID of existing firewall to use")
-	kubernetesCreateCmd.Flags().StringVarP(&createFirewall, "create-firewall", "c", "", "optional, comma-separated list of ports to open - leave blank for default (80,443,6443) or you can use \"all\"")
+	kubernetesCreateCmd.Flags().StringVarP(&createFirewall, "create-firewall", "c", "", "optional, semicolon-separated list of ports to open - leave blank for default (80;443;6443) or you can use \"all\"")
 
 	kubernetesRenameCmd.Flags().StringVarP(&kubernetesNewName, "name", "n", "", "the new name for the cluster.")
 

--- a/cmd/kubernetes_create.go
+++ b/cmd/kubernetes_create.go
@@ -29,11 +29,12 @@ Notes:
 * When no CIDR notation is provided, the port will get 0.0.0.0/0 (open to public) as default CIDR notation
 * When a CIDR notation is provided without slash and number segment, it will default to /32
 * Within a rule, you can use comma separator for multiple ports to have same CIDR notation
+* To separate between rules, you can use semicolon symbol and wrap everything in double quotes (see below)
 * So the following would all be valid:
-    * 80,443,6443:0.0.0.0/0;8080:1.2.3.4 (open 80,443,6443 to public and 8080 just for 1.2.3.4/32)
-    * 80,443,6443;6000-6500:4.4.4.4/24 (open 80,443,6443 to public and 6000 to 6500 just for 4.4.4.4/24)
+    * "80,443,6443:0.0.0.0/0;8080:1.2.3.4" (open 80,443,6443 to public and 8080 just for 1.2.3.4/32)
+    * "80,443,6443;6000-6500:4.4.4.4/24" (open 80,443,6443 to public and 6000 to 6500 just for 4.4.4.4/24)
 * When '--create-firewall' flag is blank, your cluster will be created with the following rules:
-    * 80,443,6443:0.0.0.0/0 (open 80,443,6443 to public)
+    * "80;443;6443" (open 80,443,6443 to public)
 * To open all ports for public access, "all" can be provided to '--create-firewall' flag (not recommended)
 `
 
@@ -197,8 +198,6 @@ var kubernetesCreateCmd = &cobra.Command{
 			}
 			configKubernetes.Applications = installApplications
 		}
-
-		// fmt.Printf("DEBUG: %+v\n", configKubernetes)
 
 		if !mergeConfigKubernetes && saveConfigKubernetes {
 			if utility.UserConfirmedOverwrite("kubernetes config", defaultYes) {

--- a/cmd/kubernetes_create.go
+++ b/cmd/kubernetes_create.go
@@ -26,13 +26,14 @@ Notes:
 * The '--create-firewall' flag can accept:
     * an optional end port using 'start_port-end_port' format (e.g. 8000-8100)
     * an optional CIDR notation (e.g. 0.0.0.0/0)
-* When no CIDR notation is provided, the port will get 0.0.0.0/0 as default CIDR notation
-* When a CIDR notation is provided without slash notation, it will default to /32
+* When no CIDR notation is provided, the port will get 0.0.0.0/0 (open to public) as default CIDR notation
+* When a CIDR notation is provided without slash and number segment, it will default to /32
+* Within a rule, you can use comma separator for multiple ports to have same CIDR notation
 * So the following would all be valid:
-    * 443,80,6443:0.0.0.0/0,8080:1.2.3.4
-    * 443,80,6443:0.0.0.0/0,8080:1.2.3.4,8081:8.8.8.8/32,8082:1.1.1.1/24,5000-5500:1.2.3.4,6000-6500:4.4.4.4/24
+    * 80,443,6443:0.0.0.0/0;8080:1.2.3.4 (open 80,443,6443 to public and 8080 just for 1.2.3.4/32)
+    * 80,443,6443;6000-6500:4.4.4.4/24 (open 80,443,6443 to public and 6000 to 6500 just for 4.4.4.4/24)
 * When '--create-firewall' flag is blank, your cluster will be created with the following rules:
-    * 80:0.0.0.0/0,443:0.0.0.0/0,6443:0.0.0.0/0
+    * 80,443,6443:0.0.0.0/0 (open 80,443,6443 to public)
 * To open all ports for public access, "all" can be provided to '--create-firewall' flag (not recommended)
 `
 
@@ -128,7 +129,7 @@ var kubernetesCreateCmd = &cobra.Command{
 		}
 
 		if createFirewall == "" {
-			configKubernetes.FirewallRule = "80,443,6443"
+			configKubernetes.FirewallRule = "80;443;6443"
 		} else {
 			configKubernetes.FirewallRule = createFirewall
 		}
@@ -196,6 +197,8 @@ var kubernetesCreateCmd = &cobra.Command{
 			}
 			configKubernetes.Applications = installApplications
 		}
+
+		// fmt.Printf("DEBUG: %+v\n", configKubernetes)
 
 		if !mergeConfigKubernetes && saveConfigKubernetes {
 			if utility.UserConfirmedOverwrite("kubernetes config", defaultYes) {


### PR DESCRIPTION
Close #149