### PR TITLE
Add support to set API key from environment variables

### DIFF
--- a/cmd/apikey.go
+++ b/cmd/apikey.go
@@ -47,4 +47,7 @@ func init() {
 	apikeyCmd.AddCommand(apikeyRemoveCmd)
 	apikeyCmd.AddCommand(apikeyCurrentCmd)
 	apikeyCmd.AddCommand(apikeyShowCmd)
+
+	// Flags for "civo apikey save" command
+	apikeySaveCmd.Flags().BoolVar(&loadApiKeyFromEnv, "load-from-env", false, "When set, the key will be loaded from $CIVO_API_KEY_NAME and $CIVO_API_KEY")
 }

--- a/cmd/apikey.go
+++ b/cmd/apikey.go
@@ -49,5 +49,5 @@ func init() {
 	apikeyCmd.AddCommand(apikeyShowCmd)
 
 	// Flags for "civo apikey save" command
-	apikeySaveCmd.Flags().BoolVar(&loadApiKeyFromEnv, "load-from-env", false, "When set, the key will be loaded from $CIVO_API_KEY_NAME and $CIVO_API_KEY")
+	apikeySaveCmd.Flags().BoolVar(&loadApiKeyFromEnv, "load-from-env", false, "When set, the name and key will be taken from environment variables (see notes above)")
 }


### PR DESCRIPTION
Close #107 

---

From https://github.com/civo/cli/issues/107#issuecomment-929839953:

> When it's merged and released, it will support this flow:
> 
> ```
> $ export CIVO_API_KEY_NAME=personal
> $ export CIVO_API_KEY=<CIVO-API-KEY>
> $ civo apikey save --load-from-env
> ```
> 
> Which in turns will create/update _~/.civo.json_ file to:
> 
> ```json
> {
>  "apikeys": {
>     "personal": "<CIVO-API-KEY>"
>   },
>   "meta": {
>     "admin": false,
>     "current_apikey": "personal",
>     "default_region": "FRA1",
>     "latest_release_check": "2021-09-29T12:45:35+08:00",
>     "url": "https://api.civo.com"
>   }
> }
> ```