### PR TITLE
Update application install logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,6 +768,12 @@ Installed marketplace applications:
 +---------+-----------+-----------+--------------+
 ```
 
+**Note:** Applications like `metrics-server` are installed by default on any new cluster you create. If you don't need to install the default applications, use the `--remove-applications` flag as below:
+
+```sh
+$ civo kubernetes create apps-demo-cluster --nodes=2 --applications=Redis,Linkerd --remove-applications=metrics-server
+```
+
 #### Installing Applications to an Existing Cluster
 
 If you want to add a new application to an existing cluster, you can do so by running the `civo applications` command specifying the cluster and the app(s) you wish to add:

--- a/cmd/kubernetes_create.go
+++ b/cmd/kubernetes_create.go
@@ -201,6 +201,9 @@ var kubernetesCreateCmd = &cobra.Command{
 					utility.Warning("the app that tries to install %s is not valid", v)
 					os.Exit(1)
 				}
+				if utility.CheckIfAppHasPrefix(v) {
+					break
+				}
 			}
 			configKubernetes.Applications = installApplications
 		}

--- a/cmd/kubernetes_create.go
+++ b/cmd/kubernetes_create.go
@@ -175,6 +175,9 @@ var kubernetesCreateCmd = &cobra.Command{
 			for _, v := range strings.Split(removeapplications, ",") {
 				if utility.CheckAPPName(v) {
 					rmApp = append(rmApp, fmt.Sprintf("-%s", v))
+					if utility.Contains(rmApp, "-metrics-server") || utility.Contains(rmApp, "-traefik-v2-nodeport") {
+						continue
+					}
 				} else {
 					utility.Warning("the app that tries to remove %s is not valid", v)
 					os.Exit(1)
@@ -200,9 +203,6 @@ var kubernetesCreateCmd = &cobra.Command{
 				if !utility.CheckAPPName(v) {
 					utility.Warning("the app that tries to install %s is not valid", v)
 					os.Exit(1)
-				}
-				if utility.CheckIfAppHasPrefix(v) {
-					break
 				}
 			}
 			configKubernetes.Applications = installApplications

--- a/cmd/kubernetes_test.go
+++ b/cmd/kubernetes_test.go
@@ -27,6 +27,11 @@ func TestInstallApplications(t *testing.T) {
 			args: InstallApplicationsArgs{defaultApps: []string{"metrics-server", "traefik"}, apps: "foo", removeApps: ""},
 			want: []string{"metrics-server", "traefik", "foo"},
 		},
+		{
+			name: "Test Removal of Default Apps and Installation of other Apps",
+			args: InstallApplicationsArgs{defaultApps: []string{"metrics-server", "traefik"}, apps: "foo", removeApps: "traefik"},
+			want: []string{"metrics-server", "foo"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/kubernetes_test.go
+++ b/cmd/kubernetes_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+type InstallApplicationsArgs struct {
+	defaultApps []string
+	apps        string
+	removeApps  string
+}
+
+func TestInstallApplications(t *testing.T) {
+	var tests = []struct {
+		name string
+		args InstallApplicationsArgs
+		want []string
+	}{
+		{
+			name: "Test Removal of Default Apps",
+			args: InstallApplicationsArgs{defaultApps: []string{"metrics-server", "traefik"}, apps: "", removeApps: "traefik"},
+			want: []string{"metrics-server"},
+		},
+		{
+			name: "Test Installation of Default Apps and other Apps",
+			args: InstallApplicationsArgs{defaultApps: []string{"metrics-server", "traefik"}, apps: "foo", removeApps: ""},
+			want: []string{"metrics-server", "traefik", "foo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InstallApps(tt.args.defaultApps, tt.args.apps, tt.args.removeApps)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("InstallApps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utility/check.go
+++ b/utility/check.go
@@ -91,6 +91,14 @@ func CheckAPPName(appName string) bool {
 	return false
 }
 
+//CheckIfAppHasPrefix is a function to check if the app name has prefix "-"
+func CheckIfAppHasPrefix(appName string) bool {
+	if strings.HasPrefix(appName, "-") {
+		return true
+	}
+	return false
+}
+
 // CheckAvailability is a function to check if the user can
 // create Iaas and k8s cluster base on the result of region
 func CheckAvailability(resource string, regionSet string) (bool, string, error) {

--- a/utility/check.go
+++ b/utility/check.go
@@ -91,10 +91,12 @@ func CheckAPPName(appName string) bool {
 	return false
 }
 
-//CheckIfAppHasPrefix is a function to check if the app name has prefix "-"
-func CheckIfAppHasPrefix(appName string) bool {
-	if strings.HasPrefix(appName, "-") {
-		return true
+//Contains is a function to check if the slice contains the specified string
+func Contains(appNames []string, appName string) bool {
+	for _, app := range appNames {
+		if app == appName {
+			return true
+		}
 	}
 	return false
 }

--- a/utility/check.go
+++ b/utility/check.go
@@ -91,14 +91,24 @@ func CheckAPPName(appName string) bool {
 	return false
 }
 
-//Contains is a function to check if the slice contains the specified string
-func Contains(appNames []string, appName string) bool {
-	for _, app := range appNames {
-		if app == appName {
-			return true
+func ListDefaultApps() ([]string, error) {
+	client, err := config.CivoAPIClient()
+	if err != nil {
+		return nil, err
+	}
+
+	allApps, err := client.ListKubernetesMarketplaceApplications()
+	if err != nil {
+		return nil, err
+	}
+
+	var defaultApps []string
+	for _, v := range allApps {
+		if v.Default {
+			defaultApps = append(defaultApps, v.Name)
 		}
 	}
-	return false
+	return defaultApps, nil
 }
 
 // CheckAvailability is a function to check if the user can


### PR DESCRIPTION
## Summary

This PR aims to modify CLI code in such a way that `civo k3s create -r metrics-server, traefik-v2-nodeport` would send an empty string in applications field.

## Background

NA