### PR TITLE
Fixed error in the save sub cmd

### DIFF
--- a/cmd/apikey_save.go
+++ b/cmd/apikey_save.go
@@ -38,12 +38,18 @@ var apikeySaveCmd = &cobra.Command{
 	Use:     "save",
 	Aliases: []string{"add", "store", "create", "new"},
 	Short:   "Save a new API key",
-	Args:    cobra.MinimumNArgs(0),
 	Example: apikeySaveCmdExample,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		var name, apiKey string
 		var err error
+
+		// if arg is more than one, return an error
+		if len(args) > 0 {
+			utility.Info("This command not need arguments")
+			os.Exit(1)
+		}
+
 
 		if len(args) == 0 && !loadApiKeyFromEnv {
 			reader := bufio.NewReader(os.Stdin)

--- a/config/config.go
+++ b/config/config.go
@@ -104,7 +104,7 @@ func SaveConfig() {
 
 func checkConfigFile(filename string) error {
 	file, err := os.Stat(filename)
-	fileContend := []byte(fmt.Sprintf("{\"apikeys\":{},\"meta\":{\"admin\":false,\"current_apikey\":\"\",\"latest_release_check\":\"%s\",\"url\":\"https://api.civo.com\"}}", time.Now().Format(time.RFC3339)))
+	fileContend := []byte(fmt.Sprintf("{\"apikeys\":{},\"meta\":{\"admin\":false,\"current_apikey\":\"\",\"default_region\":\"LON1\",\"latest_release_check\":\"%s\",\"url\":\"https://api.civo.com\"}}", time.Now().Format(time.RFC3339)))
 	if os.IsNotExist(err) {
 		_, err := os.Create(filename)
 		if err != nil {


### PR DESCRIPTION
Fixed error in the save sub cmd in the apikey cmd, also we add info to that cmd saying that cmd did not need arguments

Signed-off-by: Alejandro J. Nuñez Madrazo <alejandrojnm@gmail.com>