### PR TITLE
Update env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ $ civo apikey current Demo_Test_Key
   Set the default API Key to be Demo_Test_Key
 ```
 
+By default, the Civo account credentials API Key along with other settings like region will be saved in a file called `.civo.json` in the user home directory. The default location of the file can be changed using the environment variable `CIVO_CONFIG`.
+
 #### Managing and listing API keys
 
 You can list all stored API keys in your configuration by invoking `civo apikey list` or remove one by name by using `civo apikey remove apikey_name`.

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ var Filename string
 
 // ReadConfig reads in config file and ENV variables if set.
 func ReadConfig() {
-	filename, found := os.LookupEnv("CIVOCONFIG")
+	filename, found := os.LookupEnv("CIVO_CONFIG")
 	if found {
 		Filename = filename
 	}


### PR DESCRIPTION
Rename the Civo config environment variable and document its usage

Fix: #197 , #196 