### PR TITLE
Respect `--tags` flag during instance creation

### DIFF
--- a/cmd/instance/instance_create.go
+++ b/cmd/instance/instance_create.go
@@ -244,7 +244,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if tags != "" {
-			config.TagsList = tags
+			config.Tags = strings.Split(tags, ",")
 		}
 
 		var executionTime, publicIP string


### PR DESCRIPTION
## Description
This PR fixes an issue where during instance creation, `--tags` flag was not respected.

## Related Issue
Fixes https://github.com/civo/cli/issues/242

