### PR TITLE
Allow user to use defined env key

### DIFF
--- a/cmd/region/region_current.go
+++ b/cmd/region/region_current.go
@@ -3,6 +3,7 @@ package region
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
@@ -30,13 +31,13 @@ var regionCurrentCmd = &cobra.Command{
 			return
 		}
 
-		if config.Current.Meta.DefaultRegion == args[0] {
+		if strings.ToLower(config.Current.Meta.DefaultRegion) == strings.ToLower(args[0]) {
 			fmt.Printf("You are already using that region: %s\n", utility.Red(args[0]))
 			os.Exit(1)
 		}
 
 		for _, v := range regions {
-			if v.Code == args[0] {
+			if strings.ToLower(v.Code) == strings.ToLower(args[0]) {
 				config.Current.Meta.DefaultRegion = args[0]
 				regionName = v.Name
 				config.SaveConfig()

--- a/config/config.go
+++ b/config/config.go
@@ -75,6 +75,12 @@ func loadConfig(filename string) {
 		os.Exit(1)
 	}
 
+	checkEnvVarSet, found := os.LookupEnv("CIVO_TOKEN")
+	if found {
+		Current.APIKeys = map[string]string{"tempKey": checkEnvVarSet}
+		Current.Meta.CurrentAPIKey = "tempKey"
+	}
+
 	if time.Since(Current.Meta.LatestReleaseCheck) > (24 * time.Hour) {
 		Current.Meta.LatestReleaseCheck = time.Now()
 		dataBytes, err := json.Marshal(Current)

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 			res := common.VersionCheck().Current
 			updateCmd := "civo update"
 			gitIssueLink := termlink.ColorLink("GitHub issue", "https://github.com/civo/cli/issues", "italic green")
-			fmt.Printf("Your CLI Version : %s \nPlease, run %q and retry the command \nIf you are still facing issues, please report it on our community slack or open a %s \n", res, updateCmd, gitIssueLink)
+			fmt.Printf("panic : %s \nYour CLI Version : %s \nPlease, run %q and retry the command \nIf you are still facing issues, please report it on our community slack or open a %s \n", err, res, updateCmd, gitIssueLink)
 		}
 	}()
 	cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,19 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+
 	"github.com/civo/cli/cmd"
+	"github.com/savioxavier/termlink"
 )
 
 func main() {
+	defer func() {
+		if err := recover(); err != nil {
+			updateCmd := "civo update"
+			gitIssueLink := termlink.ColorLink("GitHub issue", "https://github.com/civo/cli/issues", "italic green")
+			fmt.Printf("Please, run %q and retry the command. If you are still facing issues, please report it on our community slack or open a %s \n", updateCmd, gitIssueLink)
+		}
+	}()
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -19,15 +19,17 @@ import (
 	"fmt"
 
 	"github.com/civo/cli/cmd"
+	"github.com/civo/cli/common"
 	"github.com/savioxavier/termlink"
 )
 
 func main() {
 	defer func() {
 		if err := recover(); err != nil {
+			res := common.VersionCheck().Current
 			updateCmd := "civo update"
 			gitIssueLink := termlink.ColorLink("GitHub issue", "https://github.com/civo/cli/issues", "italic green")
-			fmt.Printf("Please, run %q and retry the command. If you are still facing issues, please report it on our community slack or open a %s \n", updateCmd, gitIssueLink)
+			fmt.Printf("Your CLI Version : %s \nPlease, run %q and retry the command \nIf you are still facing issues, please report it on our community slack or open a %s \n", res, updateCmd, gitIssueLink)
 		}
 	}()
 	cmd.Execute()


### PR DESCRIPTION
Updated config file to use a defined environment variable in place of API key if it exists.
https://github.com/civo/cli/issues/232