### PR TITLE
Firewall Rule Create-Fixed default flags issue

### DIFF
--- a/cmd/firewall/firewall.go
+++ b/cmd/firewall/firewall.go
@@ -56,7 +56,5 @@ func init() {
 	firewallRuleCreateCmd.Flags().StringVarP(&direction, "direction", "d", "ingress", "the direction of the rule can be ingress or egress (default is ingress)")
 	firewallRuleCreateCmd.Flags().StringVarP(&action, "action", "a", "allow", "the action of the rule can be allow or deny (default is allow)")
 	firewallRuleCreateCmd.Flags().StringVarP(&label, "label", "l", "", "a string that will be the displayed as the name/reference for this rule")
-	firewallRuleCreateCmd.MarkFlagRequired("direction")
-	firewallRuleCreateCmd.MarkFlagRequired("action")
 	firewallRuleCreateCmd.MarkFlagRequired("startport")
 }


### PR DESCRIPTION
Fixed the issue with Firewall Rule Create command to set actions and direction flags as optional.
https://github.com/civo/cli/issues/249

Signed-off-by: satakshigarg <satakshi@civo.com>