### PR TITLE
Respect cross-regions for object store

### DIFF
--- a/cmd/objectstore/objectstore_credential_delete.go
+++ b/cmd/objectstore/objectstore_credential_delete.go
@@ -24,10 +24,15 @@ var objectStoreCredentialDeleteCmd = &cobra.Command{
 	Example: "civo objectstore credential delete CREDENTIAL-NAME",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)
 			os.Exit(1)
+		}
+
+		if common.RegionSet != "" {
+			client.Region = common.RegionSet
 		}
 
 		if len(args) == 1 {

--- a/cmd/objectstore/objectstore_credential_export.go
+++ b/cmd/objectstore/objectstore_credential_export.go
@@ -19,10 +19,16 @@ var objectStoreCredentialExportCmd = &cobra.Command{
 	Short:   "Export the credentials for your Object Store.",
 	Example: "civo objectstore credential export --access-key=ACCESS_KEY --format=FORMAT (We support env and s3cfg)",
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)
 			os.Exit(1)
+		}
+
+		if common.RegionSet != "" {
+			client.Region = common.RegionSet
 		}
 
 		var key string

--- a/cmd/objectstore/objectstore_credential_list.go
+++ b/cmd/objectstore/objectstore_credential_list.go
@@ -15,10 +15,16 @@ var objectStoreCredentialListCmd = &cobra.Command{
 	Short:   "List all Object Store Credentials",
 	Example: "civo objectstore credential ls",
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)
 			os.Exit(1)
+		}
+
+		if common.RegionSet != "" {
+			client.Region = common.RegionSet
 		}
 
 		creds, err := client.ListObjectStoreCredentials()

--- a/cmd/objectstore/objectstore_credential_secret.go
+++ b/cmd/objectstore/objectstore_credential_secret.go
@@ -15,10 +15,16 @@ var objectStoreCredentialSecretCmd = &cobra.Command{
 	Short:   "Access the secret key for the Object Store by providing your access key.",
 	Example: "civo objectstore credential secret --access-key ACCESS_KEY",
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)
 			os.Exit(1)
+		}
+
+		if common.RegionSet != "" {
+			client.Region = common.RegionSet
 		}
 
 		var key string

--- a/cmd/objectstore/objectstore_credential_update.go
+++ b/cmd/objectstore/objectstore_credential_update.go
@@ -21,6 +21,8 @@ var objectStoreCredentialUpdateCmd = &cobra.Command{
 	Example: "civo objectstore credential update CREDENTIAL_NAME --access-key=ACCESS_KEY --secret-access-key=SECRET_ACCESS_KEY",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)

--- a/cmd/objectstore/objectstore_delete.go
+++ b/cmd/objectstore/objectstore_delete.go
@@ -24,10 +24,16 @@ var objectStoreDeleteCmd = &cobra.Command{
 	Example: "civo objectstore delete OBJECTSTORE_NAME",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)
 			os.Exit(1)
+		}
+
+		if common.RegionSet != "" {
+			client.Region = common.RegionSet
 		}
 
 		if len(args) == 1 {

--- a/cmd/objectstore/objectstore_list.go
+++ b/cmd/objectstore/objectstore_list.go
@@ -18,10 +18,16 @@ var objectStoreListCmd = &cobra.Command{
 	Example: `civo objectstore ls`,
 	Short:   "List all Object Stores",
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)
 			os.Exit(1)
+		}
+
+		if common.RegionSet != "" {
+			client.Region = common.RegionSet
 		}
 
 		objectStores, err := client.ListObjectStores()

--- a/cmd/objectstore/objectstore_show.go
+++ b/cmd/objectstore/objectstore_show.go
@@ -20,10 +20,16 @@ var objectStoreShowCmd = &cobra.Command{
 	Short:   "Prints information about an Object Store",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)
 			os.Exit(1)
+		}
+
+		if common.RegionSet != "" {
+			client.Region = common.RegionSet
 		}
 
 		objectStore, err := client.FindObjectStore(args[0])

--- a/cmd/objectstore/objectstore_update.go
+++ b/cmd/objectstore/objectstore_update.go
@@ -18,6 +18,8 @@ var objectStoreUpdateCmd = &cobra.Command{
 	Example: "civo objectstore resize OBJECTSTORE_NAME --size SIZE",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
 		client, err := config.CivoAPIClient()
 		if err != nil {
 			utility.Error("Creating the connection to Civo's API failed with %s", err)


### PR DESCRIPTION
Object store commands don't respect the `--region` flag. This PR fixes that.