### PR TITLE
Suggest next available size when creating an object store

### DIFF
--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -41,11 +41,19 @@ var objectStoreCreateCmd = &cobra.Command{
 			bucketSize = 500
 		} else if bucketSize < 500 {
 			utility.YellowConfirm("The minimum size to create an object store is 500 GB. Would you like to create an %s of 500 GB? (y/n) ? ", utility.Green("object store"))
-			utility.ReadUserInput(os.Stdin)
+			err := utility.ReadUserInput(os.Stdin)
+			if err != nil {
+				utility.Error("Unable to parse users input: %s", err)
+				os.Exit(1)
+			}
 			bucketSize = 500
 		} else if bucketSize%500 != 0 {
 			utility.YellowConfirm("The size to create an object store must be a multiple of 500. Would you like to create an %s of %d GB instead? (y/n) ? ", utility.Green("object store"), bucketSize+(500-bucketSize%500))
-			utility.ReadUserInput(os.Stdin)
+			err := utility.ReadUserInput(os.Stdin)
+			if err != nil {
+				utility.Error("Unable to parse users input: %s", err)
+				os.Exit(1)
+			}
 			bucketSize = bucketSize + (500 - bucketSize%500)
 		}
 

--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -39,9 +39,9 @@ var objectStoreCreateCmd = &cobra.Command{
 
 		if bucketSize == 0 {
 			bucketSize = 500
-		} else if bucketSize < 500 {
+		} else if bucketSize > 0 && bucketSize < 500 {
 			utility.YellowConfirm("The minimum size to create an object store is 500 GB. Would you like to create an %s of 500 GB? (y/n) ? ", utility.Green("object store"))
-			err := utility.ReadUserInputAndCheckIfYes(os.Stdin)
+			_, err := utility.UserAccepts(os.Stdin)
 			if err != nil {
 				utility.Error("Unable to parse the input: %s", err)
 				os.Exit(1)
@@ -49,7 +49,7 @@ var objectStoreCreateCmd = &cobra.Command{
 			bucketSize = 500
 		} else if bucketSize%500 != 0 {
 			utility.YellowConfirm("The size to create an object store must be a multiple of 500. Would you like to create an %s of %d GB instead? (y/n) ? ", utility.Green("object store"), bucketSize+(500-bucketSize%500))
-			err := utility.ReadUserInputAndCheckIfYes(os.Stdin)
+			_, err := utility.UserAccepts(os.Stdin)
 			if err != nil {
 				utility.Error("Unable to parse the input: %s", err)
 				os.Exit(1)

--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -41,17 +41,17 @@ var objectStoreCreateCmd = &cobra.Command{
 			bucketSize = 500
 		} else if bucketSize < 500 {
 			utility.YellowConfirm("The minimum size to create an object store is 500 GB. Would you like to create an %s of 500 GB? (y/n) ? ", utility.Green("object store"))
-			err := utility.ReadUserInput(os.Stdin)
+			err := utility.ReadUserInputAndCheckIfYes(os.Stdin)
 			if err != nil {
-				utility.Error("Unable to parse users input: %s", err)
+				utility.Error("Unable to parse the input: %s", err)
 				os.Exit(1)
 			}
 			bucketSize = 500
 		} else if bucketSize%500 != 0 {
 			utility.YellowConfirm("The size to create an object store must be a multiple of 500. Would you like to create an %s of %d GB instead? (y/n) ? ", utility.Green("object store"), bucketSize+(500-bucketSize%500))
-			err := utility.ReadUserInput(os.Stdin)
+			err := utility.ReadUserInputAndCheckIfYes(os.Stdin)
 			if err != nil {
-				utility.Error("Unable to parse users input: %s", err)
+				utility.Error("Unable to parse the input: %s", err)
 				os.Exit(1)
 			}
 			bucketSize = bucketSize + (500 - bucketSize%500)

--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -39,6 +39,14 @@ var objectStoreCreateCmd = &cobra.Command{
 
 		if bucketSize == 0 {
 			bucketSize = 500
+		} else if bucketSize < 500 {
+			utility.YellowConfirm("The minimum size to create an object store is 500 GB. Would you like to create an %s of 500 GB? (y/n) ? ", utility.Green("object store"))
+			utility.ReadUserInput(os.Stdin)
+			bucketSize = 500
+		} else if bucketSize%500 != 0 {
+			utility.YellowConfirm("The size to create an object store must be a multiple of 500. Would you like to create an %s of %d GB instead? (y/n) ? ", utility.Green("object store"), bucketSize+(500-bucketSize%500))
+			utility.ReadUserInput(os.Stdin)
+			bucketSize = bucketSize + (500 - bucketSize%500)
 		}
 
 		var credential *civogo.ObjectStoreCredential

--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -37,9 +37,7 @@ var objectStoreCreateCmd = &cobra.Command{
 			client.Region = common.RegionSet
 		}
 
-		if bucketSize == 0 {
-			bucketSize = 500
-		} else if bucketSize > 0 && bucketSize < 500 {
+		if bucketSize < 500 {
 			utility.YellowConfirm("The minimum size to create an object store is 500 GB. Would you like to create an %s of 500 GB? (y/n) ? ", utility.Green("object store"))
 			_, err := utility.UserAccepts(os.Stdin)
 			if err != nil {

--- a/utility/confirmation.go
+++ b/utility/confirmation.go
@@ -89,12 +89,17 @@ func UserConfirmedOverwrite(resourceType string, ignoringConfirmed bool) bool {
 }
 
 // ReadUserInput reads user input.
-func ReadUserInput(in io.Reader) (string, error) {
+func ReadUserInput(in io.Reader) error {
 	reader := bufio.NewReader(in)
 	answer, err := reader.ReadString('\n')
 	if err != nil {
-		return "", err
+		return err
 	}
 	answer = strings.TrimRight(answer, "\r\n")
-	return strings.ToLower(answer), nil
+	strings.ToLower(answer)
+	if answer != "y" && answer != "ye" && answer != "yes" {
+		return fmt.Errorf("invalid user input")
+	}
+
+	return nil
 }

--- a/utility/confirmation.go
+++ b/utility/confirmation.go
@@ -88,18 +88,18 @@ func UserConfirmedOverwrite(resourceType string, ignoringConfirmed bool) bool {
 	return true
 }
 
-// ReadUserInputAndCheckIfYes is a function that can retrieve user input in form of string and checks if it is a yes.
-func ReadUserInputAndCheckIfYes(in io.Reader) error {
+// UserAccepts is a function that can retrieve user input in form of string and checks if it is a yes.
+func UserAccepts(in io.Reader) (bool, error) {
 	reader := bufio.NewReader(in)
 	answer, err := reader.ReadString('\n')
 	if err != nil {
-		return err
+		return false, err
 	}
 	answer = strings.TrimRight(answer, "\r\n")
 	strings.ToLower(answer)
 	if answer != "y" && answer != "ye" && answer != "yes" {
-		return fmt.Errorf("invalid user input")
+		return false, fmt.Errorf("invalid user input")
 	}
 
-	return nil
+	return true, nil
 }

--- a/utility/confirmation.go
+++ b/utility/confirmation.go
@@ -88,8 +88,8 @@ func UserConfirmedOverwrite(resourceType string, ignoringConfirmed bool) bool {
 	return true
 }
 
-// ReadUserInput reads user input.
-func ReadUserInput(in io.Reader) error {
+// ReadUserInputAndCheckIfYes is a function that can retrieve user input in form of string and checks if it is a yes.
+func ReadUserInputAndCheckIfYes(in io.Reader) error {
 	reader := bufio.NewReader(in)
 	answer, err := reader.ReadString('\n')
 	if err != nil {

--- a/utility/confirmation.go
+++ b/utility/confirmation.go
@@ -87,3 +87,14 @@ func UserConfirmedOverwrite(resourceType string, ignoringConfirmed bool) bool {
 
 	return true
 }
+
+// ReadUserInput reads user input.
+func ReadUserInput(in io.Reader) (string, error) {
+	reader := bufio.NewReader(in)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	answer = strings.TrimRight(answer, "\r\n")
+	return strings.ToLower(answer), nil
+}


### PR DESCRIPTION
## Description

Minimum size to create an Object Store is 500 and they should be created in multiples of 500 GB. If the user passes a size > 500, which is not a multiple, the CLI will suggest the next available size.