### PR TITLE
Mark required args and flags

### DIFF
--- a/cmd/objectstore/objectstore.go
+++ b/cmd/objectstore/objectstore.go
@@ -57,9 +57,11 @@ func init() {
 	//Credential commands
 	objectStoreCredentialCmd.AddCommand(objectStoreCredentialSecretCmd)
 	objectStoreCredentialSecretCmd.Flags().StringVarP(&accessKey, "access-key", "a", "", "Access Key")
+	objectStoreCredentialSecretCmd.MarkFlagRequired("access-key")
 	objectStoreCredentialCmd.AddCommand(objectStoreCredentialExportCmd)
 	objectStoreCredentialExportCmd.Flags().StringVarP(&accessKey, "access-key", "a", "", "Access Key")
 	objectStoreCredentialExportCmd.Flags().StringVarP(&format, "format", "", "env", "Format of the output (We support env and s3cfg formats.)")
+	objectStoreCredentialExportCmd.MarkFlagRequired("access-key")
 	objectStoreCredentialCmd.AddCommand(objectStoreCredentialListCmd)
 	objectStoreCredentialCmd.AddCommand(objectStoreCredentialCreateCmd)
 	objectStoreCredentialCmd.AddCommand(objectStoreCredentialUpdateCmd)

--- a/cmd/objectstore/objectstore_credential_create.go
+++ b/cmd/objectstore/objectstore_credential_create.go
@@ -21,6 +21,7 @@ var objectStoreCredentialCreateCmd = &cobra.Command{
 	Long: `Create a new Object Store Credential with preexisting access key and secret key
 		civo objectstore credential create CREDENTIAL_NAME --access-key ACCESS_KEY --secret-key SECRET_KEY
 	`,
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
 


### PR DESCRIPTION
## Description

Add minimum args for credential create command and mark `--access-key` flag required for `export` and `secret` commands for credentials.