### PR TITLE
Fix example in "civo network update" command

### DIFF
--- a/cmd/network/network_update.go
+++ b/cmd/network/network_update.go
@@ -13,7 +13,7 @@ import (
 var networkUpdateCmd = &cobra.Command{
 	Use:     "update",
 	Aliases: []string{"change", "modify"},
-	Example: "civo network rm OLD_NAME NEW_NAME",
+	Example: "civo network update OLD_NAME NEW_NAME",
 	Short:   "Rename a network",
 	Args:    cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Within the `civo network update` command the current text of the `Examples` field is

```bash
Examples:
civo network rm OLD_NAME NEW_NAME
```

This PR fixes the typo replacing "rm" with "update"