### PR TITLE
Added "rm" alias to delete IP

### DIFF
--- a/cmd/ip/ip_delete.go
+++ b/cmd/ip/ip_delete.go
@@ -14,7 +14,7 @@ import (
 
 var ipDeleteCmd = &cobra.Command{
 	Use:     "delete",
-	Aliases: []string{"unallocate", "free", "remove"},
+	Aliases: []string{"unallocate", "free", "remove", "rm"},
 	Example: `civo ip delete 127.0.0.1 
 civo ip delete server-1
 civo ip delete <ip id>


### PR DESCRIPTION
Aliased ```civo ip rm``` to delete IP
https://github.com/civo/cli/issues/277
Signed-off-by: satakshigarg <satakshi@civo.com>