### PR TITLE
fix: deprecated version of actions - go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,13 +8,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
### Problem 

Both `actions/setup-go@v1` and `actions/checkout@v2` action currently uses Node v12 to run, which is soon going to be deprecated. Here is the GitHub Blog about that [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

### Proposed changes.

Updated both go and checkout actions to the latest version.

### Warning Screenshot

<img width="1494" alt="Screenshot 2022-11-24 at 1 30 47 PM" src="https://user-images.githubusercontent.com/51878265/203726160-3118713f-2466-4ee5-98a0-953d2d946438.png">


