### PR TITLE
Fix application install logic when creating cluster

### DIFF
--- a/cmd/kubernetes/kubernetes_create.go
+++ b/cmd/kubernetes/kubernetes_create.go
@@ -283,6 +283,7 @@ func InstallApps(defaultApps []string, apps, removeApps string) []string {
 
 	if apps != "" {
 		appsToInstall = strings.Split(apps, ",")
+		appsToInstall = append(appsToInstall, defaultApps...)
 	} else {
 		appsToInstall = defaultApps
 	}

--- a/cmd/kubernetes/kubernetes_create.go
+++ b/cmd/kubernetes/kubernetes_create.go
@@ -279,20 +279,24 @@ var kubernetesCreateCmd = &cobra.Command{
 
 // InstallApps returns the list of applications to install
 func InstallApps(defaultApps []string, apps, removeApps string) []string {
-	var iApps []string
+	var appsToInstall []string
+
 	if apps != "" {
-		iApps = strings.Split(apps, ",")
+		appsToInstall = strings.Split(apps, ",")
+	} else {
+		appsToInstall = defaultApps
 	}
-	iApps = append(defaultApps, iApps...)
 
 	if removeApps != "" {
-		for i, v := range iApps {
-			for _, v2 := range strings.Split(removeApps, ",") {
-				if v == v2 {
-					iApps = append(iApps[:i], iApps[i+1:]...)
+		appsToRemove := strings.Split(removeApps, ",")
+		for _, appToRemove := range appsToRemove {
+			for i, app := range appsToInstall {
+				if app == appToRemove {
+					appsToInstall = append(appsToInstall[:i], appsToInstall[i+1:]...)
 				}
 			}
 		}
 	}
-	return iApps
+
+	return appsToInstall
 }


### PR DESCRIPTION
## Description

This PR fixes application install logic when creating a cluster, and respects both `--applications` and `--remove-applications` flags.