### PR TITLE
fix: deprecated version of actions - goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
 
@@ -37,7 +37,7 @@ jobs:
       #     snapcraft login --with <(echo "$SNAPCRAFT_LOGIN")
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           args: release --rm-dist
         env:


### PR DESCRIPTION
### Problem 

Both `actions/checkout@v2`, `actions/setup-go@v1`, and `goreleaser/goreleaser-action@v2` action currently uses Node v12 to run, which is soon going to be deprecated. Here is the GitHub Blog about that [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

### Proposed changes.

Updated the actions to the latest version.

### Warning Screenshot

<img width="1489" alt="Screenshot 2022-11-24 at 3 24 37 PM" src="https://user-images.githubusercontent.com/51878265/203753733-9fb8728d-aff7-481f-a09c-5414bd6aceaf.png">





