### PR TITLE
Bug Fix: k8s --save doesn't update the Kubeconfig if cluster with same name is re-created

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -71,7 +71,6 @@ func init() {
 
 	kubernetesConfigCmd.Flags().BoolVarP(&saveConfig, "save", "s", false, "save the config")
 	kubernetesConfigCmd.Flags().BoolVarP(&switchConfig, "switch", "i", false, "switch context to newly-created cluster (needs --merge flag)")
-	kubernetesConfigCmd.Flags().BoolVarP(&mergeConfig, "merge", "m", false, "merge the config with existing kubeconfig if it already exists")
 	kubernetesConfigCmd.Flags().BoolVarP(&overwriteConfig, "overwrite", "w", false, "overwrite the kubeconfig file")
 	kubernetesConfigCmd.Flags().StringVarP(&localPathConfig, "local-path", "p", fmt.Sprintf("%s/.kube/config", home), "local path to save the kubeconfig file")
 

--- a/utility/kubernetes.go
+++ b/utility/kubernetes.go
@@ -58,11 +58,11 @@ func mergeConfigs(localKubeconfigPath string, k3sconfig []byte, switchContext bo
 	var cmd *exec.Cmd
 
 	if osResult == "windows" {
-		os.Setenv("KUBECONFIG", fmt.Sprintf("%s;%s", localKubeconfigPath, file.Name()))
+		os.Setenv("KUBECONFIG", fmt.Sprintf("%s;%s", file.Name(), localKubeconfigPath))
 		cmd = exec.Command("powershell", "kubectl", "config", "view", "--merge", "--flatten")
 	} else {
 		// Append KUBECONFIGS in ENV Vars
-		appendKubeConfigENV := fmt.Sprintf("KUBECONFIG=%s:%s", localKubeconfigPath, file.Name())
+		appendKubeConfigENV := fmt.Sprintf("KUBECONFIG=%s:%s", file.Name(), localKubeconfigPath)
 		cmd = exec.Command("kubectl", "config", "view", "--merge", "--flatten")
 		cmd.Env = append(os.Environ(), appendKubeConfigENV)
 	}


### PR DESCRIPTION
## Description

This MR aims to fix a bug wherein the kubeconfig was not updated if the cluster is recreated with the same name.
Also, gets rid of the `--merge` flag as `--save` and `--merge` essentially have the same functionality. 

More reading - https://github.com/alexellis/k3sup/issues/316#issuecomment-835286329