### PR TITLE
Add conditions to cluster show and list commands

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -10,6 +10,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// ControlPlaneReady is the condition type for the control plane being ready
+	ControlPlaneReady = "ControlPlaneReady"
+	// WorkerNodesReady is the condition type for the worker nodes being ready
+	WorkerNodesReady = "WorkerNodesReady"
+	// ClusterVersionSync is the condition type for the cluster version being in sync
+	ClusterVersionSync = "ClusterVersionSync"
+)
+
 // KubernetesCmd manages Civo Kubernetes Clusters
 var KubernetesCmd = &cobra.Command{
 	Use:     "kubernetes",

--- a/cmd/kubernetes/kubernetes_list.go
+++ b/cmd/kubernetes/kubernetes_list.go
@@ -58,13 +58,13 @@ If you wish to use a custom format, the available fields are:
 			if cluster.Conditions != nil {
 				conditions := ""
 				for _, condition := range cluster.Conditions {
-					if condition.Type == "ControlPlaneReady" {
+					if condition.Type == ControlPlaneReady {
 						conditions += "Control Plane Accessible: " + string(condition.Status) + "\n"
 					}
-					if condition.Type == "WorkerNodesReady" {
+					if condition.Type == WorkerNodesReady {
 						conditions += "All Workers Up: " + string(condition.Status) + "\n"
 					}
-					if condition.Type == "ClusterVersionSync" {
+					if condition.Type == ClusterVersionSync {
 						conditions += "Cluster On Desired Version: " + string(condition.Status) + "\n"
 					}
 				}

--- a/cmd/kubernetes/kubernetes_list.go
+++ b/cmd/kubernetes/kubernetes_list.go
@@ -52,15 +52,28 @@ If you wish to use a custom format, the available fields are:
 			ow.AppendDataWithLabel("id", cluster.ID, "ID")
 			ow.AppendDataWithLabel("name", cluster.Name, "Name")
 			ow.AppendDataWithLabel("cluster_type", cluster.ClusterType, "Cluster-Type")
-			ow.AppendDataWithLabel("region", client.Region, "Region")
 			ow.AppendDataWithLabel("nodes", strconv.Itoa(len(cluster.Instances)), "Nodes")
 			ow.AppendDataWithLabel("pools", strconv.Itoa(len(cluster.Pools)), "Pools")
-			ow.AppendDataWithLabel("status", utility.ColorStatus(cluster.Status), "Status")
+
+			if cluster.Conditions != nil {
+				conditions := ""
+				for _, condition := range cluster.Conditions {
+					if condition.Type == "ControlPlaneReady" {
+						conditions += "Control Plane Accessible: " + string(condition.Status) + "\n"
+					}
+					if condition.Type == "WorkerNodesReady" {
+						conditions += "All Workers Up: " + string(condition.Status) + "\n"
+					}
+					if condition.Type == "ClusterVersionSync" {
+						conditions += "Cluster On Desired Version: " + string(condition.Status) + "\n"
+					}
+				}
+				ow.AppendDataWithLabel("conditions", conditions, "Conditions")
+			}
 
 			if common.OutputFormat == "json" || common.OutputFormat == "custom" {
 				ow.AppendDataWithLabel("status", cluster.Status, "Status")
 			}
-
 		}
 
 		switch common.OutputFormat {

--- a/cmd/kubernetes/kubernetes_show.go
+++ b/cmd/kubernetes/kubernetes_show.go
@@ -13,15 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	// ControlPlaneReady is the condition type for the control plane being ready
-	ControlPlaneReady = "ControlPlaneReady"
-	// WorkerNodesReady is the condition type for the worker nodes being ready
-	WorkerNodesReady = "WorkerNodesReady"
-	// ClusterVersionSync is the condition type for the cluster version being in sync
-	ClusterVersionSync = "ClusterVersionSync"
-)
-
 var kubernetesShowCmd = &cobra.Command{
 	Use:     "show",
 	Aliases: []string{"get", "inspect"},

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8 // indirect
 	github.com/briandowns/spinner v1.11.1
 	github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c // indirect
-	github.com/civo/civogo v0.3.37
+	github.com/civo/civogo v0.3.38
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/civo/civogo v0.3.37 h1:iNFsmv5PrfWy0J7JLw0sS0LhNaaR66m5aVRB3cvYSsA=
-github.com/civo/civogo v0.3.37/go.mod h1:ovGwXtszFiTsVq1OgKG9CtE8q8TPm+4bwE13KuJBr9E=
+github.com/civo/civogo v0.3.38 h1:ZqGtAfAOB+J3ZgDgMruNEEi1wXHzMtrDi/4mhYPefAg=
+github.com/civo/civogo v0.3.38/go.mod h1:54lv/FOf7gh6wE9ZwVdw4yBehk8V1CvU9aWa4v6dvW0=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/utility/output_writer.go
+++ b/utility/output_writer.go
@@ -30,16 +30,16 @@ func (a byLen) Swap(i, j int) {
 // OutputWriter is for printing structured data in various
 // tabular formats
 //
-//   ow := utility.NewOutputWriter()
-//   ow.StartLine()
-//   ow.AppendData("ID", instance.ID)
+//	ow := utility.NewOutputWriter()
+//	ow.StartLine()
+//	ow.AppendData("ID", instance.ID)
 //
-//   # Then one of:
-//   ow.WriteSingleObjectJSON()
-//   ow.WriteMultipleObjectsJSON()
-//   ow.WriteCustomOutput(common.OutputFields)
-//   ow.WriteKeyValues()
-//   ow.WriteTable()
+//	# Then one of:
+//	ow.WriteSingleObjectJSON()
+//	ow.WriteMultipleObjectsJSON()
+//	ow.WriteCustomOutput(common.OutputFields)
+//	ow.WriteKeyValues()
+//	ow.WriteTable()
 type OutputWriter struct {
 	Keys       []string
 	Labels     []string
@@ -203,6 +203,7 @@ func (ow *OutputWriter) WriteTable() {
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 		table.SetAutoWrapText(false)
 		table.SetAutoFormatHeaders(false)
+		table.SetRowLine(true)
 	} else {
 		table.SetBorder(false)
 	}


### PR DESCRIPTION
## Description

Adds the following conditions to cluster show and list commands - 
1. Control Plane is accessible.
2. Worker Nodes are up.
3. Cluster is on desired version.

This will solve user's confusion about what's happening with their clusters i.e "Is my cluster scaling up?" , "Is control plane unresponsive?", "Is cluster upgrading?",etc.
