### PR TITLE
Add subcommand for listing node pools

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -138,6 +138,8 @@ func init() {
 	kubernetesNodePoolInstanceDeleteCmd.MarkFlagRequired("instance-id")
 	kubernetesNodePoolCmd.AddCommand(kubernetesNodePoolInstanceListCmd)
 	kubernetesNodePoolInstanceListCmd.Flags().StringVarP(&nodePoolID, "node-pool-id", "p", "", "the ID of the node pool.")
+
+	kubernetesNodePoolCmd.AddCommand(kubernetesNodePoolListCmd)
 }
 
 func getKubernetesList(value string) []string {

--- a/cmd/kubernetes/kubernetes_nodepool_list.go
+++ b/cmd/kubernetes/kubernetes_nodepool_list.go
@@ -1,0 +1,66 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/civo/cli/common"
+	"github.com/civo/cli/config"
+	"github.com/civo/cli/utility"
+	"github.com/spf13/cobra"
+)
+
+var kubernetesNodePoolListCmd = &cobra.Command{
+	Use:     "ls",
+	Aliases: []string{"list", "all"},
+	Short:   "List all node pools in a Kubernetes cluster",
+	Example: "civo kubernetes node-pool ls CLUSTER_NAME",
+	Args:    cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
+		client, err := config.CivoAPIClient()
+		if err != nil {
+			utility.Error("Creating the connection to Civo's API failed with %s", err)
+			os.Exit(1)
+		}
+
+		cluster, err := client.FindKubernetesCluster(args[0])
+		if err != nil {
+			utility.Error("%s", err)
+			os.Exit(1)
+		}
+
+		ow := utility.NewOutputWriter()
+
+		for _, pool := range cluster.RequiredPools {
+			fmt.Println()
+			ow.WriteHeader(fmt.Sprintf("Node Pool %s", pool.ID))
+			ow.AppendDataWithLabel("ID", pool.ID, "Name")
+			ow.AppendDataWithLabel("Size", pool.Size, "Size")
+			ow.AppendDataWithLabel("Count", fmt.Sprintf("%d", pool.Count), "Count")
+			labels, err := json.Marshal(pool.Labels)
+			if err != nil {
+				fmt.Println("Error:", err)
+				return
+			}
+			ow.AppendDataWithLabel("Labels", string(labels), "Labels")
+			taints, err := json.Marshal(pool.Taints)
+			if err != nil {
+				fmt.Println("Error:", err)
+				return
+			}
+			ow.AppendDataWithLabel("Taints", string(taints), "Taints")
+			ow.WriteTable()
+		}
+
+		if common.OutputFormat == "json" {
+			ow.WriteMultipleObjectsJSON(common.PrettySet)
+		}
+
+		if common.OutputFormat == "custom" {
+			ow.WriteCustomOutput(common.OutputFields)
+		}
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8 // indirect
 	github.com/briandowns/spinner v1.11.1
 	github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c // indirect
-	github.com/civo/civogo v0.3.39
+	github.com/civo/civogo v0.3.40
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/civo/civogo v0.3.39 h1:oo9MlLaP9+iDdibFlgacCVd9771BOnOF1vt6G3PeQGg=
-github.com/civo/civogo v0.3.39/go.mod h1:54lv/FOf7gh6wE9ZwVdw4yBehk8V1CvU9aWa4v6dvW0=
+github.com/civo/civogo v0.3.40 h1:zgFkMvs5HM5OUkhUqrv0xSmXboFncEW14GpEGXp1y+Q=
+github.com/civo/civogo v0.3.40/go.mod h1:54lv/FOf7gh6wE9ZwVdw4yBehk8V1CvU9aWa4v6dvW0=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
## Description

Adds a new command `civo k3s node-pool ls <CLUSTER-NAME>` which lists all node pools in that specific cluster.