### PR TITLE
Hide sizes for kfaas and dbaas in instance sizes

### DIFF
--- a/cmd/instance/instance_size.go
+++ b/cmd/instance/instance_size.go
@@ -38,9 +38,10 @@ var instanceSizeCmd = &cobra.Command{
 		}
 
 		for _, size := range sizes {
-			if !strings.Contains(size.Name, ".kube.") && !strings.Contains(size.Name, ".k3s.") {
-				filter = append(filter, size)
+			if strings.Contains(size.Name, ".kube.") || strings.Contains(size.Name, ".k3s.") || strings.Contains(size.Name, ".db.") || strings.Contains(size.Name, ".kf.") {
+				continue
 			}
+			filter = append(filter, size)
 		}
 
 		ow := utility.NewOutputWriter()


### PR DESCRIPTION
## Description

Hides sizes for kubeflow clusters and databases in `instance size` command.