### PR TITLE
fix for create pool

### DIFF
--- a/cmd/kubernetes/kubernetes_nodepool_create.go
+++ b/cmd/kubernetes/kubernetes_nodepool_create.go
@@ -46,11 +46,6 @@ var kubernetesNodePoolCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		newPool := []civogo.KubernetesClusterPoolConfig{}
-		for _, v := range kubernetesFindCluster.Pools {
-			newPool = append(newPool, civogo.KubernetesClusterPoolConfig{ID: v.ID, Count: v.Count, Size: v.Size})
-		}
-
 		var poolID string
 		if nodePoolName != "" {
 			poolID = nodePoolName
@@ -63,7 +58,7 @@ var kubernetesNodePoolCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		kcpc := civogo.KubernetesClusterPoolConfig{ID: poolID, Count: numTargetNodesPool, Size: targetNodesPoolSize}
+		poolConfig := civogo.KubernetesClusterPoolConfig{ID: poolID, Count: numTargetNodesPool, Size: targetNodesPoolSize}
 		if publicIpNodePool {
 			if config.Current.RegionToFeatures != nil {
 				if !config.Current.RegionToFeatures[client.Region].PublicIPNodePools {
@@ -71,16 +66,10 @@ var kubernetesNodePoolCreateCmd = &cobra.Command{
 					os.Exit(1)
 				}
 			}
-			kcpc.PublicIPNodePool = publicIpNodePool
+			poolConfig.PublicIPNodePool = publicIpNodePool
 		}
 
-		newPool = append(newPool, kcpc)
-
-		configKubernetes := &civogo.KubernetesClusterConfig{
-			Pools: newPool,
-		}
-
-		kubernetesCluster, err := client.UpdateKubernetesCluster(kubernetesFindCluster.ID, configKubernetes)
+		kubernetesCluster, err := client.CreateKubernetesPool(kubernetesFindCluster.ID, &poolConfig)
 		if err != nil {
 			utility.Error("%s", err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8 // indirect
 	github.com/briandowns/spinner v1.11.1
 	github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c // indirect
-	github.com/civo/civogo v0.3.45
+	github.com/civo/civogo v0.3.46
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/civo/civogo v0.3.45 h1:H9rrCKhO3vAQ249koZODdE/ESAXWAZQaYuQafqzJZr8=
-github.com/civo/civogo v0.3.45/go.mod h1:54lv/FOf7gh6wE9ZwVdw4yBehk8V1CvU9aWa4v6dvW0=
+github.com/civo/civogo v0.3.46 h1:F95+85P2sqM73bsJVQEgOmDTYCNMkg8uDL/dano6jTU=
+github.com/civo/civogo v0.3.46/go.mod h1:54lv/FOf7gh6wE9ZwVdw4yBehk8V1CvU9aWa4v6dvW0=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
Create pool fails because still using the PUT `/v2/kubernetes/clusters/{id}` endpoint.
This MR implements the client for the new endpoint `POST /v2/kubernetes/clusters/{id}/pools` for creating new pools.

Already tested in production on the real case which was failing.