### PR TITLE
show k8s deprecated versions

### DIFF
--- a/cmd/kubernetes/kubernetes_list_version.go
+++ b/cmd/kubernetes/kubernetes_list_version.go
@@ -44,9 +44,6 @@ If you wish to use a custom format, the available fields are:
 
 		ow := utility.NewOutputWriter()
 		for _, version := range kubeVersions {
-			if version.Type == "deprecated" {
-				continue
-			}
 
 			ow.StartLine()
 


### PR DESCRIPTION
To abide by the civo api, this MR aims to show k8s deprecated versions from the CLI, even if it's not possible to spin up new clusters with those, but at least they're supported by the system (in its old clusters) 