### PR TITLE
Add default firewall flag for network create command

### DIFF
--- a/cmd/network/network.go
+++ b/cmd/network/network.go
@@ -30,6 +30,7 @@ func init() {
 
 	networkCreateCmd.Flags().StringVarP(&cidrV4, "cidr-v4", "", "", "Custom IPv4 CIDR")
 	networkCreateCmd.Flags().StringSliceVarP(&nameserversV4, "nameservers-v4", "", nil, "Custom list of IPv4 nameservers (up to three, comma-separated)")
+	networkCreateCmd.Flags().BoolVarP(&createDefaultFirewall, "create-default-firewall", "", false, "Create a default firewall for the network")
 
 	// Flag binding for networkConnectCmd
 	networkConnectCmd.Flags().IntVar(&vlanID, "vlan-id", 0, "VLAN ID to connect")

--- a/cmd/network/network_create.go
+++ b/cmd/network/network_create.go
@@ -2,8 +2,9 @@ package network
 
 import (
 	"fmt"
-	"github.com/civo/civogo"
 	"os"
+
+	"github.com/civo/civogo"
 
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
@@ -12,14 +13,15 @@ import (
 )
 
 var (
-	cidrV4        string
-	nameserversV4 []string
+	cidrV4                string
+	nameserversV4         []string
+	createDefaultFirewall bool
 )
 
 var networkCreateCmd = &cobra.Command{
 	Use:     "create",
 	Aliases: []string{"new", "add"},
-	Example: "civo network create NAME",
+	Example: "civo network create NAME [flags]",
 	Short:   "Create a new network",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -56,6 +58,20 @@ var networkCreateCmd = &cobra.Command{
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			fmt.Printf("Created a network called %s with ID %s\n", utility.Green(network.Label), utility.Green(network.ID))
+		}
+
+		if createDefaultFirewall {
+			firewall, err := client.NewFirewall(&civogo.FirewallConfig{
+				Name:      fmt.Sprintf("%s - Default", network.Label),
+				NetworkID: network.ID,
+				// CreateRules: &createRules,
+				Region: client.Region,
+			})
+			if err != nil {
+				utility.Error("%s", err)
+				os.Exit(1)
+			}
+			fmt.Printf("Created a default firewall %s\n", utility.Green(firewall.Name))
 		}
 	},
 }

--- a/cmd/network/network_create.go
+++ b/cmd/network/network_create.go
@@ -64,8 +64,7 @@ var networkCreateCmd = &cobra.Command{
 			firewall, err := client.NewFirewall(&civogo.FirewallConfig{
 				Name:      fmt.Sprintf("%s - Default", network.Label),
 				NetworkID: network.ID,
-				// CreateRules: &createRules,
-				Region: client.Region,
+				Region:    client.Region,
 			})
 			if err != nil {
 				utility.Error("%s", err)


### PR DESCRIPTION
## Description

- Adds a new flag `--create-default-firewall` for `network create` command to allow users create a default firewall for their networks.

## Background

https://github.com/civo/cli/issues/428