### PR TITLE
Added flags to delete all dependent resources and configurations with…

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -142,6 +142,11 @@ func init() {
 	kubernetesNodePoolInstanceListCmd.Flags().StringVarP(&nodePoolID, "node-pool-id", "p", "", "the ID of the node pool.")
 
 	kubernetesNodePoolCmd.AddCommand(kubernetesNodePoolListCmd)
+
+	// Define the flags for the kubernetesRemoveCmd
+	kubernetesRemoveCmd.Flags().BoolVar(&deleteVolumes, "delete-volumes", false, "Delete dependent volumes")
+	kubernetesRemoveCmd.Flags().BoolVar(&keepFirewalls, "keep-firewalls", false, "Keep dependent firewalls")
+	kubernetesRemoveCmd.Flags().BoolVar(&keepKubeconfig, "keep-kubeconfig", false, "Keep kubeconfig")
 }
 
 func getKubernetesList(value string) []string {


### PR DESCRIPTION
As referenced in issue #406, this update includes the following enhancements:

Flags for Deletion Operations:
--delete-volumes: Deletes associated volumes when deleting a Kubernetes cluster.
--keep-firewalls: Retains dependent firewalls during deletion.
--keep-kubeconfig: Preserves Kubernetes configurations.

Additional Output and Messaging:
Implemented the second part of the acceptance criteria:
Alongside cluster deletion details, outputs information about remaining volumes.
Provides an informational message on stderr, suggesting the --delete-volumes flag for future use.

Error Handling:
Addressed potential error scenarios to ensure robust operation.
Please review and let me know if any changes are needed.