### PR TITLE
fix: display correct region in message when no resources are found

### DIFF
--- a/utility/output_writer.go
+++ b/utility/output_writer.go
@@ -287,7 +287,12 @@ func prettyprint(b []byte) ([]byte, error) {
 func (ow *OutputWriter) FinishAndPrintOutput() {
 	ow.finishExistingLine()
 	if len(ow.Values) == 0 {
-		region := config.Current.Meta.DefaultRegion
+		var region string
+		if common.RegionSet != "" {
+			region = common.RegionSet
+		} else {
+			region = config.Current.Meta.DefaultRegion
+		}
 		fmt.Fprintf(os.Stderr, "No resources found in region %s. For a list of regions use the command 'civo region ls'\n", region)
 	} else {
 		switch common.OutputFormat {


### PR DESCRIPTION
## Description

This PR addresses the issue in #436. It ensures the correct region is displayed when no resources are found.

## Changes

- Added a check to determine if the user has specified a region via the command line flag `--region`.
- If a region is specified, its value is used.
- If no region is specified, the default region is printed.
