### PR TITLE
fix: Reconsider CLI defaults #392

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -83,9 +83,9 @@ func init() {
 	kubernetesConfigCmd.Flags().BoolVarP(&overwriteConfig, "overwrite", "w", false, "overwrite the kubeconfig file")
 	kubernetesConfigCmd.Flags().StringVarP(&localPathConfig, "local-path", "p", fmt.Sprintf("%s/.kube/config", home), "local path to save the kubeconfig file")
 
-	kubernetesCreateCmd.Flags().StringVarP(&targetNodesSize, "size", "s", "g4s.kube.medium", "the size of nodes to create. You can list available kubernetes sizes by `civo size list -s kubernetes`")
+	kubernetesCreateCmd.Flags().StringVarP(&targetNodesSize, "size", "s", "g4s.kube.xsmall", "the size of nodes to create. You can list available kubernetes sizes by `civo size list -s kubernetes`")
 	kubernetesCreateCmd.Flags().StringVarP(&networkID, "network", "t", "default", "the name of the network to use in the creation")
-	kubernetesCreateCmd.Flags().IntVarP(&numTargetNodes, "nodes", "n", 3, "the number of nodes to create (the master also acts as a node).")
+	kubernetesCreateCmd.Flags().IntVarP(&numTargetNodes, "nodes", "n", 2, "the number of nodes to create (the master also acts as a node).")
 	kubernetesCreateCmd.Flags().StringVarP(&kubernetesVersion, "version", "v", "latest", "the k3s version to use on the cluster. Defaults to the latest. Example - 'civo k3s create --version 1.21.2+k3s1'")
 	kubernetesCreateCmd.Flags().StringVarP(&applications, "applications", "a", "", "optional, use names shown by running 'civo kubernetes applications ls'")
 	kubernetesCreateCmd.Flags().StringVarP(&removeapplications, "remove-applications", "r", "", "optional, remove default application names shown by running  'civo kubernetes applications ls'")


### PR DESCRIPTION
As discussed in issue-392, I have implemented the following fixes:

Set the default node size to g4s.kube.xsmall
Set the default number of nodes to 2
Ensured firewall rules are correctly applied during cluster creation
However, I was unable to make the OS selection deterministic. The API documentation does not seem to provide any guidance on this. Could you please advise on how to achieve this?

Screenshots:
![image](https://github.com/civo/cli/assets/109286547/150c06ff-cbb5-4ee6-ac59-ea003cf7cc24)
![Screenshot from 2024-07-11 15-20-10](https://github.com/civo/cli/assets/109286547/1f6daa06-b079-4513-9fb2-9e4a6cec48e9)

Please review and let me know if any further changes are needed.

@haardikdharma10 @RealHarshThakur @uzaxirr @fernando-villalba 