### PR TITLE
Add ability to update cluster firewall

### DIFF
--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -142,6 +142,11 @@ func init() {
 	kubernetesNodePoolInstanceListCmd.Flags().StringVarP(&nodePoolID, "node-pool-id", "p", "", "the ID of the node pool.")
 
 	kubernetesNodePoolCmd.AddCommand(kubernetesNodePoolListCmd)
+
+	// Kubernetes Update
+	KubernetesCmd.AddCommand(kubernetesUpdateCmd)
+	kubernetesUpdateCmd.Flags().StringVarP(&firewall, "firewall", "", "", "the Name or ID of the firewall.")
+	kubernetesUpdateCmd.MarkFlagRequired("firewall") // At present, only the firewall can be updated, this can be changed to not required if more options are added in the future.
 }
 
 func getKubernetesList(value string) []string {

--- a/cmd/kubernetes/kubernetes_update.go
+++ b/cmd/kubernetes/kubernetes_update.go
@@ -1,0 +1,72 @@
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/civo/civogo"
+	"github.com/civo/cli/common"
+	"github.com/civo/cli/config"
+	"github.com/civo/cli/utility"
+	"github.com/spf13/cobra"
+)
+
+var firewall string
+
+var kubernetesUpdateCmd = &cobra.Command{
+	Use:     "update",
+	Aliases: []string{"edit"},
+	Short:   "Update a Kubernetes cluster",
+	Example: "civo kubernetes update CLUSTER_NAME --firewall FIREWALL_ID/NAME",
+	Args:    cobra.MinimumNArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return getAllKubernetesList(), cobra.ShellCompDirectiveNoFileComp
+		}
+		return getKubernetesList(toComplete), cobra.ShellCompDirectiveNoFileComp
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		utility.EnsureCurrentRegion()
+
+		client, err := config.CivoAPIClient()
+		if common.RegionSet != "" {
+			client.Region = common.RegionSet
+		}
+		if err != nil {
+			utility.Error("Creating the connection to Civo's API failed with %s", err)
+			os.Exit(1)
+		}
+
+		kubernetesFindCluster, err := client.FindKubernetesCluster(args[0])
+		if err != nil {
+			utility.Error("Kubernetes %s", err)
+			os.Exit(1)
+		}
+
+		if firewall == "" {
+			utility.Error("You must specify either the firewall ID or the firewall name")
+			os.Exit(1)
+		}
+
+		configKubernetes := &civogo.KubernetesClusterConfig{
+			FirewallID: firewall,
+		}
+
+		kubernetesCluster, err := client.UpdateKubernetesCluster(kubernetesFindCluster.ID, configKubernetes)
+		if err != nil {
+			utility.Error("%s", err)
+			os.Exit(1)
+		}
+
+		ow := utility.NewOutputWriterWithMap(map[string]string{"id": kubernetesCluster.ID, "name": kubernetesFindCluster.Name, "firewall_id": kubernetesCluster.FirewallID})
+
+		switch common.OutputFormat {
+		case "json":
+			ow.WriteSingleObjectJSON(common.PrettySet)
+		case "custom":
+			ow.WriteCustomOutput(common.OutputFields)
+		default:
+			fmt.Printf("The firewall for the Kubernetes cluster %s has been updated\n", utility.Green(kubernetesFindCluster.Name))
+		}
+	},
+}

--- a/cmd/kubernetes/kubernetes_update.go
+++ b/cmd/kubernetes/kubernetes_update.go
@@ -16,7 +16,7 @@ var firewall string
 var kubernetesUpdateCmd = &cobra.Command{
 	Use:     "update",
 	Aliases: []string{"edit"},
-	Short:   "Update a Kubernetes cluster",
+	Short:   "Update the configuration of your Civo Kubernetes cluster",
 	Example: "civo kubernetes update CLUSTER_NAME --firewall FIREWALL_ID/NAME",
 	Args:    cobra.MinimumNArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8 // indirect
 	github.com/briandowns/spinner v1.11.1
 	github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c // indirect
-	github.com/civo/civogo v0.3.70
+	github.com/civo/civogo v0.3.73
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/briandowns/spinner v1.11.1/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX
 github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c h1:aprLqMn7gSPT+vdDSl+/E6NLEuArwD/J7IWd8bJt5lQ=
 github.com/c4milo/unpackit v0.0.0-20170704181138-4ed373e9ef1c/go.mod h1:Ie6SubJv/NTO9Q0UBH0QCl3Ve50lu9hjbi5YJUw03TE=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/civo/civogo v0.3.70 h1:QPuFm5EmpkScbdFo5/6grcG2xcvd/lgdolOtENT04Ac=
-github.com/civo/civogo v0.3.70/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
+github.com/civo/civogo v0.3.73 h1:thkNnkziU+xh+MEOChIUwRZI1forN20+SSAPe/VFDME=
+github.com/civo/civogo v0.3.73/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
## Description

This PR- 
- Adds a new command to allow updating firewall for a kubernetes cluster.
- Bumps `civogo` module to the latest version.

## Fixes
https://github.com/civo/cli/issues/444

