### PR TITLE
Create an output writer per pool

### DIFF
--- a/cmd/kubernetes/kubernetes_nodepool_list.go
+++ b/cmd/kubernetes/kubernetes_nodepool_list.go
@@ -35,6 +35,7 @@ var kubernetesNodePoolListCmd = &cobra.Command{
 		ow := utility.NewOutputWriter()
 
 		for _, pool := range cluster.RequiredPools {
+			ow = utility.NewOutputWriter()
 			fmt.Println()
 			ow.WriteHeader(fmt.Sprintf("Node Pool %s", pool.ID))
 			ow.AppendDataWithLabel("ID", pool.ID, "Name")


### PR DESCRIPTION
Having more NodePools and listing them, given a specific cluster, was making panicking the cli:

```
sempronio18@fedora:~$ civo kubernetes node-pool ls testcluster

Node Pool 794b8a9e-3362-4c29-8856-2a68639ac552:
+-------------------------------------------------------------+------------------------+------------+------------+-----------+
| Name                                                                | Size                       | Count | Labels    | Taints |
+-------------------------------------- ----------------------+-------------------------+-----------+-------------+----------+
| 794b8a9e-3362-4c29-8856-2a68639ac552 | g4s.kube.xsmall |     1      | null         | null     |
+-------------------------------------------------------------+-------------------------+-----------+-------------+----------+

Node Pool 15637345-4beb-485a-92de-69f31567cc9c:
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/civo/cli/utility.(*OutputWriter).AppendDataWithLabel(...)
        /home/runner/work/cli/cli/utility/output_writer.go:111
github.com/civo/cli/cmd/kubernetes.glob..func20(0x1bd1ec0?, {0xc00069a940, 0x1, 0x1?})
        /home/runner/work/cli/cli/cmd/kubernetes/kubernetes_nodepool_list.go:40 +0x12d6
github.com/spf13/cobra.(*Command).execute(0x1bd1ec0, {0xc00069a920, 0x1, 0x1})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:854 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0x1bc2d40)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x39c
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
github.com/civo/cli/cmd.Execute()
        /home/runner/work/cli/cli/cmd/root.go:121 +0x25
main.main()
        /home/runner/work/cli/cli/main.go:27 +0x17
```

I solved creating a new writer for each pool instead of reusing the old one