### PR TITLE
fix: display private_IPv4 in database list output

### DIFF
--- a/cmd/database/database_list.go
+++ b/cmd/database/database_list.go
@@ -53,6 +53,7 @@ var dbListCmd = &cobra.Command{
 			ow.AppendDataWithLabel("host", db.PublicIPv4, "Host")
 			ow.AppendDataWithLabel("port", strings.Join(ports, ","), "Port")
 			ow.AppendDataWithLabel("status", db.Status, "Status")
+			ow.AppendDataWithLabel("private_ipv4", db.PrivateIPv4, "Private IPv4")
 
 			if common.OutputFormat == "json" || common.OutputFormat == "custom" {
 				ow.AppendDataWithLabel("firewall_id", db.FirewallID, "Firewall ID")


### PR DESCRIPTION
This PR closes #455 


Result:

<img width="560" alt="Screenshot 2024-09-06 124122" src="https://github.com/user-attachments/assets/45d23178-c52d-444a-9571-8ca06120cf0a">

<img width="660" alt="Screenshot 2024-09-06 124315" src="https://github.com/user-attachments/assets/c0b02928-20ee-4c00-9d8a-6ceb1a8271db">
