### PR TITLE
feat: Introduce --no-default-rules flag, deprecate --create-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,11 +1290,18 @@ $ civo firewall create civocli_demo
 Created a firewall called civocli_demo with ID ab2a25d7-edd4-4ecd-95c4-58cb6bc402de
 ```
 
-You can also create a firewall without any default rules by using the flag `-r` or `--create-rules` set to `false`. In both cases, the usage is like:
+By default, this newly created firewall will come with the default rules applied.
+
+To create a firewall without any default rules, use the `--no-default-rules` flag:
+
+```bash
+civo firewall create new_firewall_name --no-default-rules
+```
+
+You can also use the `-r` or `--create-rules` flag set to `false` to create a firewall without default rules, but it is deprecated and will be removed in future versions. In both cases, the usage is like:
 
 ```bash
 civo firewall create new_firewall_name --create-rules=false
-
 ```
 
 You will then be able to **configure rules** that allow connections to and from your instance by adding a new rule using `civo firewall rule create firewall_id` with the required and your choice of optional parameters, listed here and used in an example below:

--- a/cmd/firewall/firewall.go
+++ b/cmd/firewall/firewall.go
@@ -40,7 +40,8 @@ func init() {
 	FirewallCmd.AddCommand(firewallRemoveCmd)
 
 	firewallCreateCmd.Flags().StringVarP(&firewallnetwork, "network", "n", "default", "the network to create the firewall")
-	firewallCreateCmd.Flags().BoolVarP(&createRules, "create-rules", "r", true, "the create rules flag is used to create the default firewall rules, if is not defined will be set to true")
+	firewallCreateCmd.Flags().BoolVarP(&createRules, "create-rules", "r", true, "the create rules flag is used to create the default firewall rules, if is not defined will be set to true (deprecated)")
+	firewallCreateCmd.Flags().BoolVarP(&noDefaultRules, "no-default-rules", "", false, "the no-default-rules flag will ensure no default rules are created for the firewall, if not defined it will be set to false")
 
 	// Firewalls rule cmd
 	FirewallCmd.AddCommand(firewallRuleCmd)
@@ -57,4 +58,7 @@ func init() {
 	firewallRuleCreateCmd.Flags().StringVarP(&action, "action", "a", "allow", "the action of the rule can be allow or deny (default is allow)")
 	firewallRuleCreateCmd.Flags().StringVarP(&label, "label", "l", "", "a string that will be the displayed as the name/reference for this rule")
 	firewallRuleCreateCmd.MarkFlagRequired("startport")
+
+	// Mark the create-rules flag as deprecated
+	firewallCreateCmd.Flags().MarkDeprecated("create-rules", "it will be removed in future versions. Default firewall rules are created by default. Use --no-default-rules flag to create firewalls without them.\n")
 }

--- a/cmd/firewall/firewall_create.go
+++ b/cmd/firewall/firewall_create.go
@@ -13,6 +13,7 @@ import (
 
 var firewallnetwork string
 var createRules bool
+var noDefaultRules bool
 var defaultNetwork *civogo.Network
 
 var firewallCreateCmd = &cobra.Command{
@@ -21,6 +22,18 @@ var firewallCreateCmd = &cobra.Command{
 	Short:   "Create a new firewall",
 	Example: "civo firewall create NAME",
 	Args:    cobra.MinimumNArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		createRulesFlag := cmd.Flags().Lookup("create-rules")
+		noDefaultRulesFlag := cmd.Flags().Lookup("no-default-rules")
+
+		if createRulesFlag.Changed && noDefaultRulesFlag.Changed {
+			utility.Error("conflicting flags: --create-rules and --no-default-rules cannot be used together")
+			os.Exit(1)
+		}
+		if noDefaultRules {
+			createRules = false
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
 


### PR DESCRIPTION
This PR addresses the issue in #446 

In here, I,

- Added a new `--no-default-rules` flag to control default firewall rule creation.
- Marked `--create-rules` as deprecated but kept for backward compatibility.
- Added a deprecation warning for `--create-rules` usage.
- Error out when both the flags are used simultaneously.
- Updated the documentation to reflect the changes.


Why deprecate `--create-rules` flag ?
-------------------
If we see the [documentation](https://github.com/civo/cli?tab=readme-ov-file#configuring-a-new-firewall), it seems `--create-rules` was introduced to give users a way to create firewalls without any default firewall rules set. 

<img width="608" alt="image" src="https://github.com/user-attachments/assets/3d1eabba-912d-4163-b4ff-1616726f81a3">

But, now that we have `--no-default-rules` flag, deprecating (not removing)  `--create-rules` I feel is the obvious next step here.

> Note: when a flag is [deprecated](https://pkg.go.dev/github.com/spf13/pflag@v1.0.5#FlagSet.MarkDeprecated), It continues to function but does not show up in help or usage messages.

------------------------------------------------------------------------------------

**Result:**

1. Firewall correctly created with default rules without `--create-rules` flag

<img width="740" alt="Screenshot 2024-09-06 194631" src="https://github.com/user-attachments/assets/e2662366-01b8-4e53-be43-65000985da41">

2.When we use `--create-rules` flag, a warning message flashes, but default rule still gets created as before.

<img width="919" alt="Screenshot 2024-09-06 195339" src="https://github.com/user-attachments/assets/be13dcc6-0597-45f4-9fa6-3a4d468d75d2">

<img width="735" alt="image" src="https://github.com/user-attachments/assets/e1588f75-2ad9-4f8c-854e-44a4a1f3df3c">

3. Backward compatibility not getting affected:

<img width="915" alt="image" src="https://github.com/user-attachments/assets/950894a0-b537-4b22-a6c0-39bc748cfeb8">

4. Firewall correctly getting created with `--no-default-rules`

<img width="666" alt="Screenshot 2024-09-06 195446" src="https://github.com/user-attachments/assets/28926ab3-7179-4612-824a-7b944c970c14">

5. No firewall rules applied with `--no-default-rules` flag

<img width="603" alt="Screenshot 2024-09-06 195526" src="https://github.com/user-attachments/assets/3ccf43f7-d013-4c53-b6be-fede9c0c169f">

6. Error out when both flags are used:

<img width="918" alt="image" src="https://github.com/user-attachments/assets/2f6bd6e6-cce0-40d7-aac7-a14b64e9caa4">

7. Updated Documentation

<img width="806" alt="Screenshot 2024-09-06 200008" src="https://github.com/user-attachments/assets/cfeeb877-2158-4a53-90fb-a39f75fb21dd">

