### PR TITLE
fix error when trying to run apikey sub-commands

### DIFF
--- a/cmd/apikey/apikey_current.go
+++ b/cmd/apikey/apikey_current.go
@@ -15,6 +15,8 @@ var apikeyCurrentCmd = &cobra.Command{
 	Short:   "Set the current API key",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		config.LoadConfig(config.GetConfigFilename())
+
 		index, err := apiKeyFind(args[0])
 		if err != nil {
 			utility.Error("Unable find the API key %s", err.Error())
@@ -26,6 +28,5 @@ var apikeyCurrentCmd = &cobra.Command{
 			config.SaveConfig()
 			fmt.Printf("Set the default API Key to be %s\n", utility.Green(index))
 		}
-
 	},
 }

--- a/cmd/apikey/apikey_list.go
+++ b/cmd/apikey/apikey_list.go
@@ -20,6 +20,8 @@ If you wish to use a custom format, the available fields are:
 
 Example: civo apikey ls -o custom -f "Name: Key"`,
 	Run: func(cmd *cobra.Command, args []string) {
+		config.LoadConfig(config.GetConfigFilename())
+
 		keys := make([]string, 0, len(config.Current.APIKeys))
 		for k := range config.Current.APIKeys {
 			keys = append(keys, k)

--- a/cmd/apikey/apikey_remove.go
+++ b/cmd/apikey/apikey_remove.go
@@ -19,6 +19,8 @@ var apikeyRemoveCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	Example: "civo apikey remove NAME",
 	Run: func(cmd *cobra.Command, args []string) {
+		config.LoadConfig(config.GetConfigFilename())
+
 		index, err := apiKeyFind(args[0])
 		if err != nil {
 			utility.Error("Unable to find the API key %s", err.Error())
@@ -49,6 +51,5 @@ var apikeyRemoveCmd = &cobra.Command{
 		} else {
 			fmt.Println("Operation aborted.")
 		}
-
 	},
 }

--- a/cmd/apikey/apikey_save.go
+++ b/cmd/apikey/apikey_save.go
@@ -110,6 +110,17 @@ var apikeySaveCmd = &cobra.Command{
 			apiKey = apiKeyEnv
 		}
 
+		if config.Current.APIKeys == nil {
+			filename := config.GetConfigFilename()
+			err := config.CheckConfigFile(filename)
+			if err != nil {
+				fmt.Println(err.Error())
+				os.Exit(1)
+			}
+
+			config.ProcessConfig(filename)
+		}
+
 		config.Current.APIKeys[name] = apiKey
 		if config.Current.Meta.DefaultRegion == "" {
 			client, err := civogo.NewClientWithURL(apiKey, config.Current.Meta.URL, "")

--- a/cmd/apikey/apikey_show.go
+++ b/cmd/apikey/apikey_show.go
@@ -22,6 +22,8 @@ If you wish to use a custom format, the available fields are:
 * key
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		config.LoadConfig(config.GetConfigFilename())
+
 		keys := make([]string, 0, len(config.Current.APIKeys))
 		for k := range config.Current.APIKeys {
 			keys = append(keys, k)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,11 @@ as instances and Kubernetes clusters at Civo.com.`,
 			cmd.Help()
 		}
 	},
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if cmd.Parent().Use != "apikey" {
+			config.ReadConfig()
+		}
+	},
 }
 
 // completionCmd represents the completion command
@@ -126,8 +131,6 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(config.ReadConfig)
-
 	rootCmd.AddCommand(completionCmd)
 	completionCmd.AddCommand(completionBashCmd)
 	completionCmd.AddCommand(completionZshCmd)


### PR DESCRIPTION
```
change fixes error when trying to run `apikey` sub-commands after successfully saving an API key.

```

Reported issue can be found [here](https://github.com/civo/cli/issues/477).