### PR TITLE
fix typo in API key error message

### DIFF
--- a/cmd/apikey/apikey_current.go
+++ b/cmd/apikey/apikey_current.go
@@ -17,7 +17,7 @@ var apikeyCurrentCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		index, err := apiKeyFind(args[0])
 		if err != nil {
-			utility.Error("Unable find the API key %s", err.Error())
+			utility.Error("Unable to find the API key %s", err.Error())
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
```
change fixes typo in apikey current subcommand error message.
```