### PR TITLE
fix: display correct cluster type during creation with --wait flag

### DIFF
--- a/cmd/kubernetes/kubernetes_create.go
+++ b/cmd/kubernetes/kubernetes_create.go
@@ -225,7 +225,7 @@ var kubernetesCreateCmd = &cobra.Command{
 
 			stillCreating := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Prefix = fmt.Sprintf("Creating a %s node k3s cluster of %s instances called %s... ", strconv.Itoa(kubernetesCluster.NumTargetNode), kubernetesCluster.TargetNodeSize, kubernetesCluster.Name)
+			s.Prefix = fmt.Sprintf("Creating a %s node %v cluster of %s instances called %s... ", strconv.Itoa(kubernetesCluster.NumTargetNode), clusterType, kubernetesCluster.TargetNodeSize, kubernetesCluster.Name)
 			s.Start()
 
 			for stillCreating {


### PR DESCRIPTION
When you create a cluster with `--wait` flag, the spinner message says, creating a `k3s` cluster, even if the cluster type is `talos`, now it takes the value from from `--cluster-type` flag, or defaults to `k3s` if nothing specified.

**Issue:**

If you see, we are creating a `talos` cluster, but the spinner message says `k3s`:

<img width="753" alt="Screenshot 2024-10-17 202844" src="https://github.com/user-attachments/assets/450661e3-52c4-4d42-86aa-c1b036aed56d">

------------------------------------------

**Result:**

Correctly picking up the cluster type now:

<img width="681" alt="Screenshot 2024-10-17 213207" src="https://github.com/user-attachments/assets/25f52304-4c1d-4d8e-99e4-bf9abbc1e669">

Rightly defaulting to `k3s`:

<img width="910" alt="Screenshot 2024-10-18 013946" src="https://github.com/user-attachments/assets/0d5aea5d-44ff-4d49-afd4-e4a6c98df56a">
