### PR TITLE
fix API related CMDS crash on wrong apikey

### DIFF
--- a/cmd/apikey/apikey.go
+++ b/cmd/apikey/apikey.go
@@ -42,6 +42,8 @@ func apiKeyFind(search string) (string, error) {
 
 func init() {
 
+	config.SkipAPIInitialization = true
+
 	APIKeyCmd.AddCommand(apikeyListCmd)
 	APIKeyCmd.AddCommand(apikeySaveCmd)
 	APIKeyCmd.AddCommand(apikeyRemoveCmd)

--- a/config/config.go
+++ b/config/config.go
@@ -87,7 +87,6 @@ func loadConfig(filename string) {
 
 	// Skip API initialization if the flag is set
 	if !SkipAPIInitialization {
-		fmt.Println("HIII CURRENT META")
 		if Current.Meta.CurrentAPIKey != "" && Current.RegionToFeatures == nil {
 			Current.RegionToFeatures, err = regionsToFeature()
 			if err != nil {


### PR DESCRIPTION
fixes: #464 

Previously, the loadConfig function always attempted to fetch `regionsToFeature`(which calls the GET regions API) , even for commands that didn’t need this data (e.g.,` civo apikey remove`).

If the saved API key was invalid, this API call would fail, causing the entire command to break.
By introducing the `SkipAPIInitialization` flag, commands can signal that API-dependent logic should be skipped, avoiding unnecessary API interactions for the cmds that dont require interaction with API