### PR TITLE
Stderr progress output

### DIFF
--- a/cmd/instance/instance_create.go
+++ b/cmd/instance/instance_create.go
@@ -291,6 +291,7 @@ If you wish to use a custom format, the available fields are:
 		if wait {
 			stillCreating := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s.Writer = os.Stderr
 			s.Prefix = fmt.Sprintf("Creating instance (%s)... ", resp.Hostname)
 			s.Start()
 

--- a/cmd/instance/instance_stop.go
+++ b/cmd/instance/instance_stop.go
@@ -51,6 +51,7 @@ If you wish to use a custom format, the available fields are:
 		if waitStop {
 			stillStopping := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s.Writer = os.Stderr
 			s.Prefix = "Stopping instance... "
 			s.Start()
 

--- a/cmd/kubernetes/kubernetes_create.go
+++ b/cmd/kubernetes/kubernetes_create.go
@@ -225,6 +225,7 @@ var kubernetesCreateCmd = &cobra.Command{
 
 			stillCreating := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s.Writer = os.Stderr
 			s.Prefix = fmt.Sprintf("Creating a %s node k3s cluster of %s instances called %s... ", strconv.Itoa(kubernetesCluster.NumTargetNode), kubernetesCluster.TargetNodeSize, kubernetesCluster.Name)
 			s.Start()
 

--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -108,6 +108,7 @@ var objectStoreCreateCmd = &cobra.Command{
 			startTime := utility.StartTime()
 			stillCreating := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s.Writer = os.Stderr
 			s.Prefix = fmt.Sprintf("Creating an Object Store with maxSize %d, called %s... ", store.MaxSize, store.Name)
 			s.Start()
 

--- a/cmd/objectstore/objectstore_credential_create.go
+++ b/cmd/objectstore/objectstore_credential_create.go
@@ -58,6 +58,7 @@ var objectStoreCredentialCreateCmd = &cobra.Command{
 			startTime := utility.StartTime()
 			stillCreating := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s.Writer = os.Stderr
 			s.Prefix = fmt.Sprintf("Creating an Object Store Credential with maxSize %d, called %s... ", credential.MaxSizeGB, credential.Name)
 			s.Start()
 

--- a/cmd/volume/volume_attach.go
+++ b/cmd/volume/volume_attach.go
@@ -81,6 +81,7 @@ var volumeAttachCmd = &cobra.Command{
 
 			stillAttaching := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s.Writer = os.Stderr
 			s.Prefix = "Attaching volume to the instance... "
 			s.Start()
 

--- a/cmd/volume/volume_detach.go
+++ b/cmd/volume/volume_detach.go
@@ -54,6 +54,7 @@ var volumeDetachCmd = &cobra.Command{
 
 			stillDetaching := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+			s.Writer = os.Stderr
 			s.Prefix = "Detaching the volume... "
 			s.Start()
 


### PR DESCRIPTION
fixes: #388 

By default, the spinner writes to os.Stdout. Changing it to os.Stderr ensures that the spinner’s output does not interfere with JSON or other data meant for file redirection or piping.

<img width="911" alt="Screenshot 2024-12-19 at 11 10 50 PM" src="https://github.com/user-attachments/assets/f232546a-85e0-4496-833b-be15e9be16d7" />
