### PR TITLE
Addition of waits and retries to have the instance vnc URL ready

### DIFF
--- a/cmd/instance/instance_vnc.go
+++ b/cmd/instance/instance_vnc.go
@@ -1,13 +1,20 @@
 package instance
 
 import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/pkg/browser"
 	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
-	"os"
 )
+
+// maxAttempts represents the max number of attempts (each one every 7s) to connect to the vnc URL
+const maxAttempts = 5
 
 var instanceVncCmd = &cobra.Command{
 	Use:     "vnc",
@@ -46,7 +53,16 @@ var instanceVncCmd = &cobra.Command{
 		// Display VNC details
 		utility.Info("VNC has been successfully enabled for instance: %s", instance.Hostname)
 		utility.Info("VNC URL: %s", vnc.URI)
+		utility.Info("We're preparing the VNC Console Access. This may take a while...")
+
+		err = waitEndpointReady(vnc.URI)
+		if err != nil {
+			utility.Error("VNC Console URL is not reachable: %s", err)
+			os.Exit(1)
+		}
+
 		utility.Info("Opening VNC in your default browser...")
+		time.Sleep(3 * time.Second)
 
 		// Open VNC in the browser
 		err = browser.OpenInBrowser(vnc.URI)
@@ -56,4 +72,33 @@ var instanceVncCmd = &cobra.Command{
 			utility.Info("VNC session is now active. You can access your instance's graphical interface.")
 		}
 	},
+}
+
+// endpointReady checks if the given URL endpoint is ready by sending a GET request
+// and returning true if the HTTP status code is not 503 or 40x
+func endpointReady(url string) bool {
+	utility.Info("New attempt to reach the VNC Console URI...")
+	resp, err := http.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode != http.StatusServiceUnavailable
+}
+
+// waitEndpointReady continuously checks the given URL endpoint every 5 seconds
+// until it becomes ready (i.e., it does not return an HTTP 503 status).
+func waitEndpointReady(url string) error {
+	var attempt int
+	for {
+		attempt++
+		if endpointReady(url) {
+			return nil
+		}
+		if attempt == maxAttempts {
+			return fmt.Errorf("max num of attempts reached: VNC endpoint not ready - please contact the support")
+		}
+		time.Sleep(7 * time.Second) // Wait for 7 seconds before the next attempt
+	}
 }


### PR DESCRIPTION
VNC Console access URL is not immediately ready and requires some retries.
This PR aims to perform the retries before redirecting the user to the default browser.
Manual test performed:
```bash
~/work/cli  $ go run main.go instance vnc 34e0e710-8d72-4e2a-8997-45561a87s510
Info: VNC has been successfully enabled for instance: blossom2
Info: VNC URL: https://vnc.lon1.civo.com/34e0e710-8d72-4e2a-8997-45561a87s510/vnc.html?path=34e0e710-8d72-4e2a-8997-45561a87s510/websockify
Info: We're preparing the VNC Console Access. This may take a while...
Info: New attempt to reach the VNC Console URI...
Info: New attempt to reach the VNC Console URI...
Info: Opening VNC in your default browser...
Info: VNC session is now active. You can access your instance's graphical interface.
```