### PR TITLE
Updated kubernetes create and kubernetes remove commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,13 +764,11 @@ You can create a cluster by running `civo kubernetes create` with a cluster name
 -e, --existing-firewall string     optional, ID of existing firewall to use
 -u, --firewall-rules string        optional, can be used if the --create-firewall flag is set, semicolon-separated list of ports to open (default "default")
 -h, --help                         help for create
--m, --merge                        merge the config with existing kubeconfig if it already exists.
 -t, --network string               the name of the network to use in the creation (default "default")
 -n, --nodes int                    the number of nodes to create (the master also acts as a node). (default 3)
 -r, --remove-applications string   optional, remove default application names shown by running  'civo kubernetes applications ls'
- --save                         save the config
+ --save                         save the config, merge into kubeconfig and switch automatically to the new cluster
 -s, --size string                  the size of nodes to create. (default "g4s.kube.medium")
- --switch                       switch context to newly-created cluster
 -v, --version string               the k3s version to use on the cluster. Defaults to the latest. Example - 'civo k3s create --version 1.21.2+k3s1' (default "latest")
 -w, --wait                         a simple flag (e.g. --wait) that will cause the CLI to spin and wait for the cluster to be ACTIVE
 ```
@@ -878,10 +876,10 @@ The command uses the application name as displayed by running `civo kubernetes a
 
 #### Removing the cluster
 
-If you're completely finished with a cluster you can delete it with:
+If you're completely finished with a cluster you can delete it with `civo kubernetes remove`
 
-```sh
-civo kubernetes remove my-first-cluster
+```bash
+-r, --remove          optional, removes cluster contexts from kubeconfig if found
 ```
 
 ## Kubernetes Applications

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -91,8 +91,6 @@ func init() {
 	kubernetesCreateCmd.Flags().StringVarP(&removeapplications, "remove-applications", "r", "", "optional, remove default application names shown by running  'civo kubernetes applications ls'")
 	kubernetesCreateCmd.Flags().BoolVarP(&waitKubernetes, "wait", "w", false, "a simple flag (e.g. --wait) that will cause the CLI to spin and wait for the cluster to be ACTIVE")
 	kubernetesCreateCmd.Flags().BoolVarP(&saveConfigKubernetes, "save", "", false, "save the config")
-	kubernetesCreateCmd.Flags().BoolVarP(&mergeConfigKubernetes, "merge", "m", false, "merge the config with existing kubeconfig if it already exists.")
-	kubernetesCreateCmd.Flags().BoolVarP(&switchConfigKubernetes, "switch", "", false, "switch context to newly-created cluster")
 	kubernetesCreateCmd.Flags().StringVarP(&existingFirewall, "existing-firewall", "e", "", "optional, ID of existing firewall to use")
 	kubernetesCreateCmd.Flags().StringVarP(&rulesFirewall, "firewall-rules", "u", "default", "optional, can be used if the --create-firewall flag is set, semicolon-separated list of ports to open")
 	kubernetesCreateCmd.Flags().BoolVarP(&createFirewall, "create-firewall", "c", false, "optional, create a firewall for the cluster with all open ports")
@@ -147,6 +145,8 @@ func init() {
 	KubernetesCmd.AddCommand(kubernetesUpdateCmd)
 	kubernetesUpdateCmd.Flags().StringVarP(&firewall, "firewall", "", "", "the Name or ID of the firewall.")
 	kubernetesUpdateCmd.MarkFlagRequired("firewall") // At present, only the firewall can be updated, this can be changed to not required if more options are added in the future.
+
+	kubernetesRemoveCmd.Flags().BoolVarP(&removeKubernetesConfig, "remove", "r", false, "remove the cluster configuration from kubeconfig if found")
 }
 
 func getKubernetesList(value string) []string {

--- a/cmd/kubernetes/kubernetes_remove.go
+++ b/cmd/kubernetes/kubernetes_remove.go
@@ -15,6 +15,7 @@ import (
 )
 
 var kuberneteList []utility.ObjecteList
+var removeKubernetesConfig bool
 var kubernetesRemoveCmd = &cobra.Command{
 	Use:     "remove",
 	Aliases: []string{"rm", "delete", "destroy"},
@@ -85,6 +86,9 @@ var kubernetesRemoveCmd = &cobra.Command{
 
 			for _, v := range kuberneteList {
 				_, err = client.DeleteKubernetesCluster(v.ID)
+				if removeKubernetesConfig {
+					utility.RemoveClusterConfig(v.Name)
+				}
 				if err != nil {
 					utility.Error("error deleting the kubernetes cluster: %s", err)
 					os.Exit(1)


### PR DESCRIPTION
Fixes https://github.com/civo/cli/issues/496

PR Summary -
1. Removes `--merge` and `--switch` flags. just `--save` works fine now and fulfills the requirements as mentioned in the issue
2. kubeconfig overwrites have been taken cared of along with making `--wait` flag implicit while using `--save` flag
3. Added flag to clear up kubeconfig file for the server that is being deleted. the flag naming is `--remove` for now. currently it notifies the user if the cluster being deleted is also the current-context so that user performs the needful without any facing any errors.
4. Issue mentioned the need for `civo kubernetes update-kubeconfig` but I see similar functionality already implemented - `civo kubernetes config` command. Open to discussion 
5. Updated documentation in readme
Demo ->
![Screenshot from 2025-02-08 11-40-16](https://github.com/user-attachments/assets/91239510-1add-4fb4-bc10-5f3c2072e883)

![Screenshot from 2025-02-08 11-47-31](https://github.com/user-attachments/assets/c9da000b-7385-46d1-9f6f-5795cff7a1b2)
