### PR TITLE
Implemented global --quiet (-q) flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The civo cli have multiple global options, that you can use, like this:
       --pretty          Print pretty the json output
       --region string   Choose the region to connect to, if you use this option it will use it over the default region
   -y, --yes             Automatic yes to prompts; assume "yes" as answer to all prompts and run non-interactive
+  -q, --quiet           Disables logging and run non-interactive, requires --yes flag wherever user prompts are required
 ```
 
 ## API Keys

--- a/cmd/apikey/apikey_current.go
+++ b/cmd/apikey/apikey_current.go
@@ -1,7 +1,6 @@
 package apikey
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/config"
@@ -24,7 +23,7 @@ var apikeyCurrentCmd = &cobra.Command{
 		if index != "" {
 			config.Current.Meta.CurrentAPIKey = index
 			config.SaveConfig()
-			fmt.Printf("Set the default API Key to be %s\n", utility.Green(index))
+			utility.Printf("Set the default API Key to be %s\n", utility.Green(index))
 		}
 
 	},

--- a/cmd/apikey/apikey_remove.go
+++ b/cmd/apikey/apikey_remove.go
@@ -1,7 +1,6 @@
 package apikey
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -41,13 +40,13 @@ var apikeyRemoveCmd = &cobra.Command{
 			config.SaveConfig()
 
 			if numKeys > len(config.Current.APIKeys) {
-				fmt.Printf("Removed the API Key %s\n", utility.Green(index))
+				utility.Printf("Removed the API Key %s\n", utility.Green(index))
 			} else {
 				utility.Error("The API Key %q couldn't be found", args[0])
 				os.Exit(1)
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 
 	},

--- a/cmd/apikey/apikey_save.go
+++ b/cmd/apikey/apikey_save.go
@@ -2,7 +2,6 @@ package apikey
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -59,9 +58,14 @@ var apikeySaveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		if len(args) == 0 && common.Quiet {
+			utility.Info("You need to use the non-interactive way when in quiet mode")
+			os.Exit(1)
+		}
+
 		if len(args) == 0 && !loadAPIKeyFromEnv {
 			reader := bufio.NewReader(os.Stdin)
-			fmt.Printf("Enter a nice name for this account/API Key: ")
+			utility.Printf("Enter a nice name for this account/API Key: ")
 
 			name, err = reader.ReadString('\n')
 			if err != nil {
@@ -73,7 +77,7 @@ var apikeySaveCmd = &cobra.Command{
 			} else {
 				name = strings.TrimSuffix(name, "\n")
 			}
-			fmt.Printf("Enter the API key: ")
+			utility.Printf("Enter the API key: ")
 			apikeyBytes, err := term.ReadPassword(int(syscall.Stdin))
 			if err != nil {
 				utility.Error("Error reading api key %v", err)
@@ -140,7 +144,7 @@ var apikeySaveCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Saved the API Key %s\n", utility.Green(name))
+			utility.Printf("Saved the API Key %s\n", utility.Green(name))
 		}
 
 	},

--- a/cmd/database/database_backup_create.go
+++ b/cmd/database/database_backup_create.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/adhocore/gronx"
@@ -106,7 +105,7 @@ var dbBackupCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Database backup (%s) for database %s has been created\n", utility.Green(name), utility.Green(bk.DatabaseName))
+			utility.Printf("Database backup (%s) for database %s has been created\n", utility.Green(name), utility.Green(bk.DatabaseName))
 		}
 	},
 }

--- a/cmd/database/database_backup_delete.go
+++ b/cmd/database/database_backup_delete.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	pluralize "github.com/alejandrojnm/go-pluralize"
@@ -99,10 +98,10 @@ var dbBackupDeleteCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(backupList), "database backup"), utility.Green(strings.Join(dbNameList, ", ")))
+				utility.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(backupList), "database backup"), utility.Green(strings.Join(dbNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Println("Operation aborted")
 		}
 	},
 }

--- a/cmd/database/database_backup_list.go
+++ b/cmd/database/database_backup_list.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -82,7 +81,7 @@ func postgresScheduledBackups(backups *civogo.PaginatedDatabaseBackup) {
 		ow.WriteCustomOutput(common.OutputFields)
 	default:
 		if printMsg {
-			fmt.Println("Scheduled backup")
+			utility.Println("Scheduled backup")
 		}
 		ow.WriteTable()
 	}
@@ -119,7 +118,7 @@ func postgresManualBackups(backups *civogo.PaginatedDatabaseBackup) {
 		ow.WriteCustomOutput(common.OutputFields)
 	default:
 		if printMsg {
-			fmt.Println("Manual backups")
+			utility.Println("Manual backups")
 		}
 		ow.WriteTable()
 	}
@@ -153,7 +152,7 @@ func mysqlBackups(backups *civogo.PaginatedDatabaseBackup) {
 		ow.WriteCustomOutput(common.OutputFields)
 	default:
 		if printMsg {
-			fmt.Println("Manual backups")
+			utility.Println("Manual backups")
 		}
 		ow.WriteTable()
 	}

--- a/cmd/database/database_backup_update.go
+++ b/cmd/database/database_backup_update.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -75,7 +74,7 @@ var dbBackupUpdateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Database backup (%s) for database %s has been update\n", utility.Green(bk.Name), utility.Green(bk.DatabaseName))
+			utility.Printf("Database backup (%s) for database %s has been update\n", utility.Green(bk.Name), utility.Green(bk.DatabaseName))
 		}
 	},
 }

--- a/cmd/database/database_create.go
+++ b/cmd/database/database_create.go
@@ -178,10 +178,13 @@ var dbCreateCmd = &cobra.Command{
 			startTime := utility.StartTime()
 
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
-			s.Prefix = fmt.Sprintf("Create a database called %s ", db.Name)
-			s.Start()
+			var s *spinner.Spinner
+			if !common.Quiet {
+				s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+				s.Writer = os.Stderr
+				s.Prefix = fmt.Sprintf("Create a database called %s ", db.Name)
+				s.Start()
+			}
 
 			for stillCreating {
 				databaseCheck, err := client.FindDatabase(db.ID)
@@ -191,7 +194,9 @@ var dbCreateCmd = &cobra.Command{
 				}
 				if databaseCheck.Status == "Ready" {
 					stillCreating = false
-					s.Stop()
+					if !common.Quiet {
+						s.Stop()
+					}
 				} else {
 					time.Sleep(2 * time.Second)
 				}
@@ -208,9 +213,9 @@ var dbCreateCmd = &cobra.Command{
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			if executionTime != "" {
-				fmt.Printf("Database (%s) type %s version %s with ID %s and size %s has been created in %s\nTo get fetch the database credentials use the command:\n\ncivo database credentials %s\n", utility.Green(db.Name), strings.ToLower(db.Software), db.SoftwareVersion, db.ID, db.Size, executionTime, db.Name)
+				utility.Printf("Database (%s) type %s version %s with ID %s and size %s has been created in %s\nTo get fetch the database credentials use the command:\n\ncivo database credentials %s\n", utility.Green(db.Name), strings.ToLower(db.Software), db.SoftwareVersion, db.ID, db.Size, executionTime, db.Name)
 			} else {
-				fmt.Printf("Database (%s) type %s version %s with ID %s and size %s has been created\nTo get fetch the database credentials use the command:\n\ncivo database credentials %s\n", utility.Green(db.Name), strings.ToLower(db.Software), db.SoftwareVersion, db.ID, db.Size, db.Name)
+				utility.Printf("Database (%s) type %s version %s with ID %s and size %s has been created\nTo get fetch the database credentials use the command:\n\ncivo database credentials %s\n", utility.Green(db.Name), strings.ToLower(db.Software), db.SoftwareVersion, db.ID, db.Size, db.Name)
 			}
 		}
 	},

--- a/cmd/database/database_delete.go
+++ b/cmd/database/database_delete.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	pluralize "github.com/alejandrojnm/go-pluralize"
@@ -95,10 +94,10 @@ var dbDeleteCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(backupList), "database"), utility.Green(strings.Join(dbNameList, ", ")))
+				utility.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(backupList), "database"), utility.Green(strings.Join(dbNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Println("Operation aborted")
 		}
 	},
 }

--- a/cmd/database/database_restore.go
+++ b/cmd/database/database_restore.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"fmt"
-
 	"github.com/civo/civogo"
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
@@ -67,10 +65,10 @@ var dbRestoreCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("Restoring database %s from from backup %s\n", utility.Green(db.Name), utility.Green(backup))
+				utility.Printf("Restoring database %s from from backup %s\n", utility.Green(db.Name), utility.Green(backup))
 			}
 		} else {
-			fmt.Println("Aborted")
+			utility.Println("Aborted")
 		}
 
 	},

--- a/cmd/database/database_show.go
+++ b/cmd/database/database_show.go
@@ -48,7 +48,7 @@ var dbShowCmd = &cobra.Command{
 		ow := utility.NewOutputWriter()
 
 		ow.StartLine()
-		fmt.Println()
+		utility.Println()
 		ow.AppendDataWithLabel("id", db.ID, "ID")
 		ow.AppendDataWithLabel("name", db.Name, "Name")
 		ow.AppendDataWithLabel("status", db.Status, "Status")
@@ -73,7 +73,7 @@ var dbShowCmd = &cobra.Command{
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			ow.WriteKeyValues()
-			fmt.Println("To get the credentials, run : civo db credential", db.Name)
+			utility.Println("To get the credentials, run : civo db credential", db.Name)
 		}
 	},
 }

--- a/cmd/database/database_update.go
+++ b/cmd/database/database_update.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -55,7 +54,7 @@ var dbUpdateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The Database %s was updated\n", utility.Green(findDB.Name))
+			utility.Printf("The Database %s was updated\n", utility.Green(findDB.Name))
 			os.Exit(0)
 		}
 	},

--- a/cmd/database/database_version.go
+++ b/cmd/database/database_version.go
@@ -1,11 +1,12 @@
 package database
 
 import (
+	"os"
+
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var dbVersionListCmd = &cobra.Command{

--- a/cmd/domain/domain_create.go
+++ b/cmd/domain/domain_create.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -36,10 +35,10 @@ var domainCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Created a domain called %s with ID %s\n", utility.Green(domain.Name), utility.Green(domain.ID))
-			fmt.Println("Please point your domain registrar to Civo nameservers:")
-			fmt.Printf("%s\n", utility.Green("ns0.civo.com"))
-			fmt.Printf("%s\n", utility.Green("ns1.civo.com"))
+			utility.Printf("Created a domain called %s with ID %s\n", utility.Green(domain.Name), utility.Green(domain.ID))
+			utility.Println("Please point your domain registrar to Civo nameservers:")
+			utility.Printf("%s\n", utility.Green("ns0.civo.com"))
+			utility.Printf("%s\n", utility.Green("ns1.civo.com"))
 		}
 	},
 }

--- a/cmd/domain/domain_record_create.go
+++ b/cmd/domain/domain_record_create.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -83,7 +82,7 @@ var domainRecordCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Created %s record %s for %s with a TTL of %s seconds and with a priority of %s with ID %s", utility.Green(string(record.Type)), utility.Green(record.Name), utility.Green(domain.Name), utility.Green(strconv.Itoa(record.TTL)), utility.Green(strconv.Itoa(record.Priority)), utility.Green(record.ID))
+			utility.Printf("Created %s record %s for %s with a TTL of %s seconds and with a priority of %s with ID %s", utility.Green(string(record.Type)), utility.Green(record.Name), utility.Green(domain.Name), utility.Green(strconv.Itoa(record.TTL)), utility.Green(strconv.Itoa(record.Priority)), utility.Green(record.ID))
 		}
 	},
 }

--- a/cmd/domain/domain_record_remove.go
+++ b/cmd/domain/domain_record_remove.go
@@ -98,10 +98,10 @@ var domainRecordRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The domain %s (%s) has been deleted\n", pluralize.Pluralize(len(domainRecordList), "record"), strings.Join(domainRecordNameList, ", "))
+				utility.Printf("The domain %s (%s) has been deleted\n", pluralize.Pluralize(len(domainRecordList), "record"), strings.Join(domainRecordNameList, ", "))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 
 	},

--- a/cmd/domain/domain_remove.go
+++ b/cmd/domain/domain_remove.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	pluralize "github.com/alejandrojnm/go-pluralize"
@@ -86,10 +85,10 @@ var domainRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(domainList), "domain"), utility.Green(strings.Join(domainNameList, ", ")))
+				utility.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(domainList), "domain"), utility.Green(strings.Join(domainNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Println("Operation aborted")
 		}
 	},
 }

--- a/cmd/firewall/firewall_create.go
+++ b/cmd/firewall/firewall_create.go
@@ -1,7 +1,6 @@
 package firewall
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -79,7 +78,7 @@ var firewallCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Created a firewall called %s with ID %s\n", utility.Green(firewall.Name), utility.Green(firewall.ID))
+			utility.Printf("Created a firewall called %s with ID %s\n", utility.Green(firewall.Name), utility.Green(firewall.ID))
 		}
 	},
 }

--- a/cmd/firewall/firewall_remove.go
+++ b/cmd/firewall/firewall_remove.go
@@ -2,7 +2,6 @@ package firewall
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	pluralize "github.com/alejandrojnm/go-pluralize"
@@ -90,10 +89,10 @@ var firewallRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(firewallList), "firewall"), utility.Green(strings.Join(firewallNameList, ", ")))
+				utility.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(firewallList), "firewall"), utility.Green(strings.Join(firewallNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/firewall/firewall_rule_create.go
+++ b/cmd/firewall/firewall_rule_create.go
@@ -92,15 +92,15 @@ var firewallRuleCreateCmd = &cobra.Command{
 		default:
 			if rule.Label == "" {
 				if newRuleConfig.EndPort == newRuleConfig.StartPort {
-					fmt.Printf("Created a firewall rule to %s, %s access to port %s %s %s with ID %s\n", utility.Green(newRuleConfig.Action), utility.Green(newRuleConfig.Direction), utility.Green(newRuleConfig.StartPort), directionValue, utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+					utility.Printf("Created a firewall rule to %s, %s access to port %s %s %s with ID %s\n", utility.Green(newRuleConfig.Action), utility.Green(newRuleConfig.Direction), utility.Green(newRuleConfig.StartPort), directionValue, utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
 				} else {
-					fmt.Printf("Created a firewall rule to %s, %s access to ports %s-%s %s %s with ID %s\n", utility.Green(newRuleConfig.Action), utility.Green(newRuleConfig.Direction), utility.Green(newRuleConfig.StartPort), utility.Green(newRuleConfig.EndPort), directionValue, utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+					utility.Printf("Created a firewall rule to %s, %s access to ports %s-%s %s %s with ID %s\n", utility.Green(newRuleConfig.Action), utility.Green(newRuleConfig.Direction), utility.Green(newRuleConfig.StartPort), utility.Green(newRuleConfig.EndPort), directionValue, utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
 				}
 			} else {
 				if newRuleConfig.EndPort == newRuleConfig.StartPort {
-					fmt.Printf("Created a firewall rule called %s to %s, %s access to port %s %s %s with ID %s\n", utility.Green(rule.Label), utility.Green(newRuleConfig.Action), utility.Green(newRuleConfig.Direction), utility.Green(newRuleConfig.StartPort), directionValue, utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+					utility.Printf("Created a firewall rule called %s to %s, %s access to port %s %s %s with ID %s\n", utility.Green(rule.Label), utility.Green(newRuleConfig.Action), utility.Green(newRuleConfig.Direction), utility.Green(newRuleConfig.StartPort), directionValue, utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
 				} else {
-					fmt.Printf("Created a firewall rule called %s to %s, %s access to ports %s-%s %s %s with ID %s\n", utility.Green(rule.Label), utility.Green(newRuleConfig.Action), utility.Green(newRuleConfig.Direction), utility.Green(newRuleConfig.StartPort), utility.Green(newRuleConfig.EndPort), directionValue, utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
+					utility.Printf("Created a firewall rule called %s to %s, %s access to ports %s-%s %s %s with ID %s\n", utility.Green(rule.Label), utility.Green(newRuleConfig.Action), utility.Green(newRuleConfig.Direction), utility.Green(newRuleConfig.StartPort), utility.Green(newRuleConfig.EndPort), directionValue, utility.Green(strings.Join(newRuleConfig.Cidr, ", ")), rule.ID)
 				}
 			}
 		}

--- a/cmd/firewall/firewall_rule_remove.go
+++ b/cmd/firewall/firewall_rule_remove.go
@@ -102,10 +102,10 @@ var firewallRuleRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The firewall %s (%s) has been deleted\n", pluralize.Pluralize(len(firewallRuleList), "rule"), strings.Join(firewallRuleNameList, ", "))
+				utility.Printf("The firewall %s (%s) has been deleted\n", pluralize.Pluralize(len(firewallRuleList), "rule"), strings.Join(firewallRuleNameList, ", "))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 
 	},

--- a/cmd/firewall/firewall_update.go
+++ b/cmd/firewall/firewall_update.go
@@ -1,7 +1,6 @@
 package firewall
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -60,7 +59,7 @@ var firewallUpdateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The firewall called %s with ID %s was renamed to %s\n", utility.Green(firewall.Name), utility.Green(firewall.ID), utility.Green(args[1]))
+			utility.Printf("The firewall called %s with ID %s was renamed to %s\n", utility.Green(firewall.Name), utility.Green(firewall.ID), utility.Green(args[1]))
 		}
 	},
 }

--- a/cmd/instance/instance_create.go
+++ b/cmd/instance/instance_create.go
@@ -290,10 +290,13 @@ If you wish to use a custom format, the available fields are:
 
 		if wait {
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
-			s.Prefix = fmt.Sprintf("Creating instance (%s)... ", resp.Hostname)
-			s.Start()
+			var s *spinner.Spinner
+			if !common.Quiet {
+				s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+				s.Writer = os.Stderr
+				s.Prefix = fmt.Sprintf("Creating instance (%s)... ", resp.Hostname)
+				s.Start()
+			}
 
 			for stillCreating {
 				instance, err = client.FindInstance(resp.ID)
@@ -303,7 +306,9 @@ If you wish to use a custom format, the available fields are:
 				}
 				if instance.Status == "ACTIVE" {
 					stillCreating = false
-					s.Stop()
+					if !common.Quiet {
+						s.Stop()
+					}
 				} else {
 					time.Sleep(2 * time.Second)
 				}
@@ -322,9 +327,9 @@ If you wish to use a custom format, the available fields are:
 
 		if common.OutputFormat == "human" {
 			if executionTime != "" {
-				fmt.Printf("The instance %s %s has been created in %s\n", utility.Green(instance.Hostname), publicIP, executionTime)
+				utility.Printf("The instance %s %s has been created in %s\n", utility.Green(instance.Hostname), publicIP, executionTime)
 			} else {
-				fmt.Printf("The instance %s has been created\n", utility.Green(instance.Hostname))
+				utility.Printf("The instance %s has been created\n", utility.Green(instance.Hostname))
 			}
 		} else {
 			ow := utility.NewOutputWriter()

--- a/cmd/instance/instance_firewall.go
+++ b/cmd/instance/instance_firewall.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
@@ -27,7 +26,7 @@ If you wish to use a custom format, the available fields are:
 		utility.EnsureCurrentRegion()
 
 		if len(args) != 2 {
-			fmt.Printf("You must specify %s parameters (you gave %s), the ID/name and the firewall ID\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
+			utility.Printf("You must specify %s parameters (you gave %s), the ID/name and the firewall ID\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
 			os.Exit(1)
 		}
 
@@ -79,7 +78,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("Set the firewall for the instance %s (%s) to %s (%s)\n", utility.Green(instance.Hostname), instance.ID, utility.Green(firewall.Name), firewall.ID)
+			utility.Printf("Set the firewall for the instance %s (%s) to %s (%s)\n", utility.Green(instance.Hostname), instance.ID, utility.Green(firewall.Name), firewall.ID)
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_ip.go
+++ b/cmd/instance/instance_ip.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -52,9 +51,9 @@ var instancePublicIPCmd = &cobra.Command{
 		}
 
 		if args[0] == "disable" {
-			fmt.Printf("Instance %s has been updated to NOT have a Public IP\n", utility.Green(instance.Hostname))
+			utility.Printf("Instance %s has been updated to NOT have a Public IP\n", utility.Green(instance.Hostname))
 		} else {
-			fmt.Printf("Instance %s has been updated to have a Public IP. IP addressed will be assigned shortly.\n", utility.Green(instance.Hostname))
+			utility.Printf("Instance %s has been updated to have a Public IP. IP addressed will be assigned shortly.\n", utility.Green(instance.Hostname))
 		}
 	},
 }

--- a/cmd/instance/instance_move_ip.go
+++ b/cmd/instance/instance_move_ip.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
@@ -28,7 +27,7 @@ If you wish to use a custom format, the available fields are:
 		utility.EnsureCurrentRegion()
 
 		if len(args) != 2 {
-			fmt.Printf("You must specify %s parameters (you gave %s), the ID/name and the public IP\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
+			utility.Printf("You must specify %s parameters (you gave %s), the ID/name and the public IP\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
 			os.Exit(1)
 		}
 
@@ -71,7 +70,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("Moved the IP %s to the instance %s (%s)\n", utility.Green(args[1]), utility.Green(instance.Hostname), instance.ID)
+			utility.Printf("Moved the IP %s to the instance %s (%s)\n", utility.Green(args[1]), utility.Green(instance.Hostname), instance.ID)
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_password.go
+++ b/cmd/instance/instance_password.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -42,7 +41,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("The instance %s (%s) has the password %s (and user %s)\n", utility.Green(instance.Hostname), instance.ID, utility.Green(instance.InitialPassword), utility.Green(instance.InitialUser))
+			utility.Printf("The instance %s (%s) has the password %s (and user %s)\n", utility.Green(instance.Hostname), instance.ID, utility.Green(instance.InitialPassword), utility.Green(instance.InitialUser))
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_reboot.go
+++ b/cmd/instance/instance_reboot.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -46,7 +45,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("The instance %s (%s) is being rebooted\n", utility.Green(instance.Hostname), instance.ID)
+			utility.Printf("The instance %s (%s) is being rebooted\n", utility.Green(instance.Hostname), instance.ID)
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_recovery.go
+++ b/cmd/instance/instance_recovery.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -47,7 +46,7 @@ Example:
 			utility.Error("%s", err)
 			os.Exit(1)
 		}
-		fmt.Println("Instance ID is: ", instance.ID)
+		utility.Println("Instance ID is: ", instance.ID)
 
 		if args[0] == "enable" {
 			_, err := client.EnableRecoveryMode(instance.ID)
@@ -64,9 +63,9 @@ Example:
 		}
 
 		if args[0] == "enable" {
-			fmt.Printf("Recovery mode has been enabled for instance %s\n", utility.Green(instance.Hostname))
+			utility.Printf("Recovery mode has been enabled for instance %s\n", utility.Green(instance.Hostname))
 		} else {
-			fmt.Printf("Recovery mode has been disabled for instance %s\n", utility.Green(instance.Hostname))
+			utility.Printf("Recovery mode has been disabled for instance %s\n", utility.Green(instance.Hostname))
 		}
 	},
 }

--- a/cmd/instance/instance_recovery_status.go
+++ b/cmd/instance/instance_recovery_status.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -63,7 +62,7 @@ Example:
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Recovery Status for instance %s (%s):\n", utility.Green(instance.Hostname), instance.ID)
+			utility.Printf("Recovery Status for instance %s (%s):\n", utility.Green(instance.Hostname), instance.ID)
 			ow.WriteKeyValues()
 		}
 	},

--- a/cmd/instance/instance_remove.go
+++ b/cmd/instance/instance_remove.go
@@ -2,7 +2,6 @@ package instance
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 
@@ -97,10 +96,10 @@ If you wish to use a custom format, the available fields are:
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(instanceList), "instance"), utility.Green(strings.Join(instanceNameList, ", ")))
+				utility.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(instanceList), "instance"), utility.Green(strings.Join(instanceNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/instance/instance_show.go
+++ b/cmd/instance/instance_show.go
@@ -122,20 +122,20 @@ If you wish to use a custom format, the available fields are:
 			ow.WriteKeyValues()
 
 			if len(instance.Notes) > 0 {
-				fmt.Println()
+				utility.Println()
 				ow.WriteSubheader("Notes")
-				fmt.Println(instance.Notes)
+				utility.Println(instance.Notes)
 			}
 
 			if len(instance.Script) > 0 {
-				fmt.Println()
+				utility.Println()
 				ow.WriteSubheader("Script")
 				sDec, err := b64.StdEncoding.DecodeString(instance.Script)
 				if err != nil {
 					utility.Error("%s", err)
 					os.Exit(1)
 				}
-				fmt.Println(string(sDec))
+				utility.Println(string(sDec))
 			}
 		}
 	},

--- a/cmd/instance/instance_soft_reboot.go
+++ b/cmd/instance/instance_soft_reboot.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -46,7 +45,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("The instance %s (%s) is being soft-rebooted\n", utility.Green(instance.Hostname), instance.ID)
+			utility.Printf("The instance %s (%s) is being soft-rebooted\n", utility.Green(instance.Hostname), instance.ID)
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_start.go
+++ b/cmd/instance/instance_start.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -47,7 +46,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("The instance %s (%s) is being started\n", utility.Green(instance.Hostname), instance.ID)
+			utility.Printf("The instance %s (%s) is being started\n", utility.Green(instance.Hostname), instance.ID)
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_stop.go
+++ b/cmd/instance/instance_stop.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -50,10 +49,13 @@ If you wish to use a custom format, the available fields are:
 
 		if waitStop {
 			stillStopping := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
-			s.Prefix = "Stopping instance... "
-			s.Start()
+			var s *spinner.Spinner
+			if !common.Quiet {
+				s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+				s.Writer = os.Stderr
+				s.Prefix = "Stopping instance... "
+				s.Start()
+			}
 
 			for stillStopping {
 				instanceCheck, err := client.FindInstance(instance.ID)
@@ -63,7 +65,9 @@ If you wish to use a custom format, the available fields are:
 				}
 				if instanceCheck.Status == "SHUTOFF" {
 					stillStopping = false
-					s.Stop()
+					if !common.Quiet {
+						s.Stop()
+					}
 				} else {
 					time.Sleep(2 * time.Second)
 				}
@@ -71,7 +75,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("The instance %s (%s) is being stopped\n", utility.Green(instance.Hostname), instance.ID)
+			utility.Printf("The instance %s (%s) is being stopped\n", utility.Green(instance.Hostname), instance.ID)
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_tag.go
+++ b/cmd/instance/instance_tag.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -52,7 +51,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("The instance %s (%s) has been tagged with '%s'\n", utility.Green(instance.Hostname), instance.ID, utility.Green(tags))
+			utility.Printf("The instance %s (%s) has been tagged with '%s'\n", utility.Green(instance.Hostname), instance.ID, utility.Green(tags))
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_update.go
+++ b/cmd/instance/instance_update.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -61,7 +60,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("The instance %s (%s) has been updated\n", utility.Green(instance.Hostname), instance.ID)
+			utility.Printf("The instance %s (%s) has been updated\n", utility.Green(instance.Hostname), instance.ID)
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/instance/instance_upgrade.go
+++ b/cmd/instance/instance_upgrade.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
@@ -30,7 +29,7 @@ If you wish to use a custom format, the available fields are:
 		utility.EnsureCurrentRegion()
 
 		if len(args) != 2 {
-			fmt.Printf("You must specify %s parameters (you gave %s), the ID/name and the new size\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
+			utility.Printf("You must specify %s parameters (you gave %s), the ID/name and the new size\n", utility.Red("2"), utility.Red(strconv.Itoa(len(args))))
 			os.Exit(1)
 		}
 
@@ -73,7 +72,7 @@ If you wish to use a custom format, the available fields are:
 		}
 
 		if common.OutputFormat == "human" {
-			fmt.Printf("The instance %s (%s) is being upgraded to %s\n", utility.Green(instance.Hostname), instance.ID, utility.Green(args[1]))
+			utility.Printf("The instance %s (%s) is being upgraded to %s\n", utility.Green(instance.Hostname), instance.ID, utility.Green(args[1]))
 		} else {
 			ow := utility.NewOutputWriter()
 			ow.StartLine()

--- a/cmd/ip/ip_assign.go
+++ b/cmd/ip/ip_assign.go
@@ -2,7 +2,6 @@ package ip
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -72,7 +71,7 @@ civo ip assign <ip id> --instance <instance ID>`,
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Assigned IP %s to instance %s\n", utility.Green(ip.Name), utility.Green(instance.Hostname))
+			utility.Printf("Assigned IP %s to instance %s\n", utility.Green(ip.Name), utility.Green(instance.Hostname))
 		}
 	},
 }

--- a/cmd/ip/ip_delete.go
+++ b/cmd/ip/ip_delete.go
@@ -2,7 +2,6 @@ package ip
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -63,10 +62,10 @@ Please make sure to delete your domains aren't pointed to it before deleting it.
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("IP called %s with ID %s was deleted\n", utility.Green(ip.Name), utility.Green(ip.ID))
+				utility.Printf("IP called %s with ID %s was deleted\n", utility.Green(ip.Name), utility.Green(ip.ID))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/ip/ip_rename.go
+++ b/cmd/ip/ip_rename.go
@@ -2,7 +2,6 @@ package ip
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -64,7 +63,7 @@ civo ip rename <ip id> server-2 `,
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Renamed IP to %s with ID %s\n", utility.Green(rename), utility.Green(ip.ID))
+			utility.Printf("Renamed IP to %s with ID %s\n", utility.Green(rename), utility.Green(ip.ID))
 		}
 	},
 }

--- a/cmd/ip/ip_reserve.go
+++ b/cmd/ip/ip_reserve.go
@@ -1,7 +1,6 @@
 package ip
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -52,9 +51,9 @@ civo ip reserve -n "server-1"`,
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			if name != "" {
-				fmt.Printf("Reserved IP called %s with ID %s\n", utility.Green(name), utility.Green(ip.ID))
+				utility.Printf("Reserved IP called %s with ID %s\n", utility.Green(name), utility.Green(ip.ID))
 			} else {
-				fmt.Printf("Reserved IP with ID %s\n", utility.Green(ip.ID))
+				utility.Printf("Reserved IP with ID %s\n", utility.Green(ip.ID))
 			}
 		}
 	},

--- a/cmd/ip/ip_unassign.go
+++ b/cmd/ip/ip_unassign.go
@@ -2,7 +2,6 @@ package ip
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -60,10 +59,10 @@ civo ip Unassign <ip id>`,
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("Unassigned IP %s from Civo resource\n", utility.Green(ip.Name))
+				utility.Printf("Unassigned IP %s from Civo resource\n", utility.Green(ip.Name))
 			}
 		} else {
-			fmt.Println("Aborted")
+			utility.Println("Aborted")
 		}
 
 	},

--- a/cmd/kubernetes/kubernetes_ recycle.go
+++ b/cmd/kubernetes/kubernetes_ recycle.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -55,7 +54,7 @@ var kubernetesRecycleCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The node (%s) was recycled\n", utility.Green(kubernetesNode))
+			utility.Printf("The node (%s) was recycled\n", utility.Green(kubernetesNode))
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_app_add.go
+++ b/cmd/kubernetes/kubernetes_app_add.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -62,7 +61,7 @@ var kubernetesAppAddCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The application was installed in the Kubernetes cluster %s\n", utility.Green(kubeCluster.Name))
+			utility.Printf("The application was installed in the Kubernetes cluster %s\n", utility.Green(kubeCluster.Name))
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_app_remove.go
+++ b/cmd/kubernetes/kubernetes_app_remove.go
@@ -67,13 +67,13 @@ var kubernetesAppRemoveCmd = &cobra.Command{
 					utility.Error("Failed to uninstall application %s (exited with code %d)\n", appName, exitError.ExitCode())
 					cmd := exec.Command("curl", "-s", fmt.Sprintf("https://raw.githubusercontent.com/civo/kubernetes-marketplace/master/%s/uninstall.sh", appName))
 					output, _ := cmd.CombinedOutput()
-					fmt.Println("--------------- Uninstall script ---------------")
-					fmt.Println(string(output))
-					fmt.Println("--------------- Uninstall output ---------------")
+					utility.Println("--------------- Uninstall script ---------------")
+					utility.Println(string(output))
+					utility.Println("--------------- Uninstall output ---------------")
 					if strings.Contains(b.String(), "command not found") {
-						fmt.Printf("Uninstall script for application %s not found \n", appName)
+						utility.Printf("Uninstall script for application %s not found \n", appName)
 					} else {
-						fmt.Println(b.String())
+						utility.Println(b.String())
 					}
 					os.Exit(1)
 				} else {

--- a/cmd/kubernetes/kubernetes_app_show.go
+++ b/cmd/kubernetes/kubernetes_app_show.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -51,7 +50,7 @@ var kubernetesAppShowCmd = &cobra.Command{
 				foundAPP = true
 				result := markdown.Render(app.PostInstall, 80, 0)
 				printPostInstall := color.S256()
-				fmt.Println()
+				utility.Println()
 				printPostInstall.Println(string(result))
 			}
 		}

--- a/cmd/kubernetes/kubernetes_config.go
+++ b/cmd/kubernetes/kubernetes_config.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 
@@ -93,7 +92,7 @@ If you wish to use a custom format, the available fields are:
 						os.Exit(1)
 					}
 				} else {
-					fmt.Println("Operation aborted.")
+					utility.Println("Operation aborted.")
 					os.Exit(1)
 				}
 			} else {
@@ -116,7 +115,7 @@ If you wish to use a custom format, the available fields are:
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			if !saveConfig {
-				fmt.Println(kube.KubeConfig)
+				utility.Println(kube.KubeConfig)
 			}
 
 		}

--- a/cmd/kubernetes/kubernetes_create.go
+++ b/cmd/kubernetes/kubernetes_create.go
@@ -208,7 +208,7 @@ var kubernetesCreateCmd = &cobra.Command{
 					os.Exit(1)
 				}
 			} else {
-				fmt.Println("Operation aborted.")
+				utility.Println("Operation aborted.")
 				os.Exit(1)
 			}
 		} else {
@@ -229,10 +229,13 @@ var kubernetesCreateCmd = &cobra.Command{
 			startTime := utility.StartTime()
 
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
-			s.Prefix = fmt.Sprintf("Creating a %d node %s cluster of %s instances called %s... ", kubernetesCluster.NumTargetNode, clusterType, kubernetesCluster.TargetNodeSize, kubernetesCluster.Name)
-			s.Start()
+			var s *spinner.Spinner
+			if !common.Quiet {
+				s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+				s.Writer = os.Stderr
+				s.Prefix = fmt.Sprintf("Creating a %d node %s cluster of %s instances called %s... ", kubernetesCluster.NumTargetNode, clusterType, kubernetesCluster.TargetNodeSize, kubernetesCluster.Name)
+				s.Start()
+			}
 
 			for stillCreating {
 				kubernetesCheck, err := client.FindKubernetesCluster(kubernetesCluster.ID)
@@ -242,7 +245,9 @@ var kubernetesCreateCmd = &cobra.Command{
 				}
 				if kubernetesCheck.Ready {
 					stillCreating = false
-					s.Stop()
+					if !common.Quiet {
+						s.Stop()
+					}
 				} else {
 					time.Sleep(2 * time.Second)
 				}
@@ -275,9 +280,9 @@ var kubernetesCreateCmd = &cobra.Command{
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			if executionTime != "" {
-				fmt.Printf("The cluster %s (%s) has been created in %s\n", utility.Green(kubernetesCluster.Name), kubernetesCluster.ID, executionTime)
+				utility.Printf("The cluster %s (%s) has been created in %s\n", utility.Green(kubernetesCluster.Name), kubernetesCluster.ID, executionTime)
 			} else {
-				fmt.Printf("The cluster %s (%s) has been created\n", utility.Green(kubernetesCluster.Name), kubernetesCluster.ID)
+				utility.Printf("The cluster %s (%s) has been created\n", utility.Green(kubernetesCluster.Name), kubernetesCluster.ID)
 			}
 
 		}

--- a/cmd/kubernetes/kubernetes_nodepool_create.go
+++ b/cmd/kubernetes/kubernetes_nodepool_create.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -89,7 +88,7 @@ var kubernetesNodePoolCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The pool (%s) was added to the cluster (%s)\n", utility.Green(poolID), utility.Green(kubernetesFindCluster.Name))
+			utility.Printf("The pool (%s) was added to the cluster (%s)\n", utility.Green(poolID), utility.Green(kubernetesFindCluster.Name))
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_nodepool_delete.go
+++ b/cmd/kubernetes/kubernetes_nodepool_delete.go
@@ -100,10 +100,10 @@ var kubernetesNodePoolDeleteCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted from the cluster (%s)\n", fmt.Sprintf("node %s", pluralize.Pluralize(len(kubernetesNodePoolList), "pool")), utility.Green(strings.Join(kubernetesPoolNameList, ", ")), utility.Green(kubernetesCluster.Name))
+				utility.Printf("The %s (%s) has been deleted from the cluster (%s)\n", fmt.Sprintf("node %s", pluralize.Pluralize(len(kubernetesNodePoolList), "pool")), utility.Green(strings.Join(kubernetesPoolNameList, ", ")), utility.Green(kubernetesCluster.Name))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_nodepool_instance_delete.go
+++ b/cmd/kubernetes/kubernetes_nodepool_instance_delete.go
@@ -63,9 +63,9 @@ var kubernetesNodePoolInstanceDeleteCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			fmt.Printf("Instance %s has been deleted from node pool %s in cluster %s\n", instanceID, nodePoolID, kubernetesFindCluster.Name)
+			utility.Printf("Instance %s has been deleted from node pool %s in cluster %s\n", instanceID, nodePoolID, kubernetesFindCluster.Name)
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_nodepool_instance_list.go
+++ b/cmd/kubernetes/kubernetes_nodepool_instance_list.go
@@ -35,7 +35,7 @@ var kubernetesNodePoolInstanceListCmd = &cobra.Command{
 		if nodePoolID == "" {
 
 			for _, pool := range cluster.Pools {
-				fmt.Println()
+				utility.Println()
 				ow.WriteHeader(fmt.Sprintf("Node Pool %s", pool.ID))
 				owPool := utility.NewOutputWriter()
 

--- a/cmd/kubernetes/kubernetes_nodepool_list.go
+++ b/cmd/kubernetes/kubernetes_nodepool_list.go
@@ -36,20 +36,20 @@ var kubernetesNodePoolListCmd = &cobra.Command{
 
 		for _, pool := range cluster.RequiredPools {
 			ow = utility.NewOutputWriter()
-			fmt.Println()
+			utility.Println()
 			ow.WriteHeader(fmt.Sprintf("Node Pool %s", pool.ID))
 			ow.AppendDataWithLabel("ID", pool.ID, "Name")
 			ow.AppendDataWithLabel("Size", pool.Size, "Size")
 			ow.AppendDataWithLabel("Count", fmt.Sprintf("%d", pool.Count), "Count")
 			labels, err := json.Marshal(pool.Labels)
 			if err != nil {
-				fmt.Println("Error:", err)
+				utility.Println("Error:", err)
 				return
 			}
 			ow.AppendDataWithLabel("Labels", string(labels), "Labels")
 			taints, err := json.Marshal(pool.Taints)
 			if err != nil {
-				fmt.Println("Error:", err)
+				utility.Println("Error:", err)
 				return
 			}
 			ow.AppendDataWithLabel("Taints", string(taints), "Taints")

--- a/cmd/kubernetes/kubernetes_nodepool_scale.go
+++ b/cmd/kubernetes/kubernetes_nodepool_scale.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -82,7 +81,7 @@ var kubernetesNodePoolScaleCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The pool (%s) was scaled to (%s) in the cluster (%s)\n", utility.Green(nodePoolID), utility.Green(strconv.Itoa(numTargetNodesPoolScale)), utility.Green(kubernetesFindCluster.Name))
+			utility.Printf("The pool (%s) was scaled to (%s) in the cluster (%s)\n", utility.Green(nodePoolID), utility.Green(strconv.Itoa(numTargetNodesPoolScale)), utility.Green(kubernetesFindCluster.Name))
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_remove.go
+++ b/cmd/kubernetes/kubernetes_remove.go
@@ -91,9 +91,9 @@ var kubernetesRemoveCmd = &cobra.Command{
 					// Try to remove the kubeconfig context before deleting the cluster
 					cmd := exec.Command("kubectl", "config", "delete-context", strings.ToLower(v.Name))
 					if err := cmd.Run(); err != nil {
-						fmt.Printf("Note: Kubeconfig context for cluster %s was not found\n", utility.Green(v.Name))
+						utility.Printf("Note: Kubeconfig context for cluster %s was not found\n", utility.Green(v.Name))
 					} else {
-						fmt.Printf("Successfully removed kubeconfig context for cluster %s\n", utility.Green(v.Name))
+						utility.Printf("Successfully removed kubeconfig context for cluster %s\n", utility.Green(v.Name))
 					}
 				}
 				_, err = client.DeleteKubernetesCluster(v.ID)
@@ -120,10 +120,10 @@ var kubernetesRemoveCmd = &cobra.Command{
 				}
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The Kubernetes %s (%s) has been deleted\n", pluralize.Pluralize(len(kuberneteList), "cluster"), utility.Green(strings.Join(kubernetesNameList, ", ")))
+				utility.Printf("The Kubernetes %s (%s) has been deleted\n", pluralize.Pluralize(len(kuberneteList), "cluster"), utility.Green(strings.Join(kubernetesNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_rename.go
+++ b/cmd/kubernetes/kubernetes_rename.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -54,7 +53,7 @@ var kubernetesRenameCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The kubernetes cluster with ID %s was renamed to %s\n", utility.Green(kubernetesCluster.ID), utility.Green(kubernetesCluster.Name))
+			utility.Printf("The kubernetes cluster with ID %s was renamed to %s\n", utility.Green(kubernetesCluster.ID), utility.Green(kubernetesCluster.Name))
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_show.go
+++ b/cmd/kubernetes/kubernetes_show.go
@@ -130,12 +130,12 @@ If you wish to use a custom format, the available fields are:
 			ow.WriteKeyValues()
 
 			if kubernetesCluster.UpgradeAvailableTo != "" {
-				fmt.Printf(utility.Red("\n* An upgrade to v%s is available. Learn more about how to upgrade: civo k3s upgrade --help"), kubernetesCluster.UpgradeAvailableTo)
-				fmt.Println()
+				utility.Printf(utility.Red("\n* An upgrade to v%s is available. Learn more about how to upgrade: civo k3s upgrade --help"), kubernetesCluster.UpgradeAvailableTo)
+				utility.Println()
 			}
 
 			if len(lbCluster) > 0 {
-				fmt.Println()
+				utility.Println()
 				ow.WriteHeader("Loadbalancers")
 				owLB := utility.NewOutputWriter()
 				for _, lb := range lbCluster {
@@ -152,7 +152,7 @@ If you wish to use a custom format, the available fields are:
 			}
 
 			if kubernetesCluster.Conditions != nil {
-				fmt.Println()
+				utility.Println()
 				ow.WriteHeader("Conditions")
 				owCond := utility.NewOutputWriter()
 				conditionFound := false
@@ -182,7 +182,7 @@ If you wish to use a custom format, the available fields are:
 			}
 
 			if len(kubernetesCluster.Instances) > 0 {
-				fmt.Println()
+				utility.Println()
 				for _, pool := range kubernetesCluster.Pools {
 					ow.WriteHeader(fmt.Sprintf("Pool (%s)", pool.ID[:6]))
 					owNode := utility.NewOutputWriter()
@@ -202,14 +202,14 @@ If you wish to use a custom format, the available fields are:
 						}
 					}
 					owNode.WriteTable()
-					fmt.Println()
+					utility.Println()
 					ow.WriteHeader("Labels")
-					fmt.Printf("kubernetes.civo.com/node-pool=%s\n", pool.ID)
-					fmt.Printf("kubernetes.civo.com/node-size=%s\n", pool.Size)
+					utility.Printf("kubernetes.civo.com/node-pool=%s\n", pool.ID)
+					utility.Printf("kubernetes.civo.com/node-size=%s\n", pool.Size)
 				}
 
 				if len(kubernetesCluster.InstalledApplications) > 0 {
-					fmt.Println()
+					utility.Println()
 					ow.WriteHeader("Applications")
 					owApp := utility.NewOutputWriter()
 
@@ -222,7 +222,7 @@ If you wish to use a custom format, the available fields are:
 						owApp.AppendData("Category", app.Category)
 					}
 					owApp.WriteTable()
-					fmt.Println()
+					utility.Println()
 				}
 			}
 		}

--- a/cmd/kubernetes/kubernetes_update.go
+++ b/cmd/kubernetes/kubernetes_update.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -66,7 +65,7 @@ var kubernetesUpdateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The firewall for the Kubernetes cluster %s has been updated\n", utility.Green(kubernetesFindCluster.Name))
+			utility.Printf("The firewall for the Kubernetes cluster %s has been updated\n", utility.Green(kubernetesFindCluster.Name))
 		}
 	},
 }

--- a/cmd/kubernetes/kubernetes_update_kubeconfig.go
+++ b/cmd/kubernetes/kubernetes_update_kubeconfig.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -39,6 +38,6 @@ var kubernetesUpdateKubeconfigCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Printf("Updated kubeconfig with cluster %s configuration\n", utility.Green(cluster.Name))
+		utility.Printf("Updated kubeconfig with cluster %s configuration\n", utility.Green(cluster.Name))
 	},
 }

--- a/cmd/kubernetes/kubernetes_upgrade.go
+++ b/cmd/kubernetes/kubernetes_upgrade.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -55,7 +54,7 @@ var kubernetesUpgradeCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The kubernetes cluster %s has started upgrading to %s\n", utility.Green(kubernetesCluster.Name), utility.Green(kubernetesNewVersion))
+			utility.Printf("The kubernetes cluster %s has started upgrading to %s\n", utility.Green(kubernetesCluster.Name), utility.Green(kubernetesNewVersion))
 		}
 	},
 }

--- a/cmd/network/network_create.go
+++ b/cmd/network/network_create.go
@@ -57,7 +57,7 @@ var networkCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Created a network called %s with ID %s\n", utility.Green(network.Label), utility.Green(network.ID))
+			utility.Printf("Created a network called %s with ID %s\n", utility.Green(network.Label), utility.Green(network.ID))
 		}
 
 		if createDefaultFirewall {
@@ -70,7 +70,7 @@ var networkCreateCmd = &cobra.Command{
 				utility.Error("%s", err)
 				os.Exit(1)
 			}
-			fmt.Printf("Created a default firewall %s\n", utility.Green(firewall.Name))
+			utility.Printf("Created a default firewall %s\n", utility.Green(firewall.Name))
 		}
 	},
 }

--- a/cmd/network/network_remove.go
+++ b/cmd/network/network_remove.go
@@ -106,10 +106,10 @@ var networkRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(networkList), "network"), utility.Green(strings.Join(networkNameList, ", ")))
+				utility.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(networkList), "network"), utility.Green(strings.Join(networkNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 
 	},

--- a/cmd/network/network_show.go
+++ b/cmd/network/network_show.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/config"
@@ -30,35 +29,35 @@ var networkShowCmd = &cobra.Command{
 		}
 
 		// Display Core Network Details
-		fmt.Println("Network Details:")
-		fmt.Printf("ID: %s\n", network.ID)
-		fmt.Printf("Name: %s\n", network.Name)
-		fmt.Printf("Default: %s\n", utility.BoolToYesNo(network.Default))
-		fmt.Printf("CIDR: %s\n", network.CIDR)
-		fmt.Printf("Status: %s\n", network.Status)
-		fmt.Printf("IPv4 Enabled: %s\n", utility.BoolToYesNo(network.IPv4Enabled))
-		fmt.Printf("IPv6 Enabled: %s\n", utility.BoolToYesNo(network.IPv6Enabled))
+		utility.Println("Network Details:")
+		utility.Printf("ID: %s\n", network.ID)
+		utility.Printf("Name: %s\n", network.Name)
+		utility.Printf("Default: %s\n", utility.BoolToYesNo(network.Default))
+		utility.Printf("CIDR: %s\n", network.CIDR)
+		utility.Printf("Status: %s\n", network.Status)
+		utility.Printf("IPv4 Enabled: %s\n", utility.BoolToYesNo(network.IPv4Enabled))
+		utility.Printf("IPv6 Enabled: %s\n", utility.BoolToYesNo(network.IPv6Enabled))
 
 		// Conditional VLAN Details
 		if network.VlanID != 0 {
-			fmt.Println("\nVLAN Details:")
-			fmt.Printf("VLAN ID: %d\n", network.VlanID)
-			fmt.Printf("Hardware Address: %s\n", network.PhysicalInterface)
-			fmt.Printf("Gateway IPv4: %s\n", network.GatewayIPv4)
-			fmt.Printf("Allocation Pool IPv4 Start: %s\n", network.AllocationPoolV4Start)
-			fmt.Printf("Allocation Pool IPv4 End: %s\n", network.AllocationPoolV4End)
+			utility.Println("\nVLAN Details:")
+			utility.Printf("VLAN ID: %d\n", network.VlanID)
+			utility.Printf("Hardware Address: %s\n", network.PhysicalInterface)
+			utility.Printf("Gateway IPv4: %s\n", network.GatewayIPv4)
+			utility.Printf("Allocation Pool IPv4 Start: %s\n", network.AllocationPoolV4Start)
+			utility.Printf("Allocation Pool IPv4 End: %s\n", network.AllocationPoolV4End)
 		} else {
-			fmt.Println("\nNo VLAN Configuration")
+			utility.Println("\nNo VLAN Configuration")
 		}
 
 		// Nameserver Details
 		if len(network.NameserversV4) > 0 || len(network.NameserversV6) > 0 {
-			fmt.Println("\nNameserver Details:")
+			utility.Println("\nNameserver Details:")
 			if len(network.NameserversV4) > 0 {
-				fmt.Printf("Nameservers IPv4: %s\n", utility.SliceToString(network.NameserversV4))
+				utility.Printf("Nameservers IPv4: %s\n", utility.SliceToString(network.NameserversV4))
 			}
 			if len(network.NameserversV6) > 0 {
-				fmt.Printf("Nameservers IPv6: %s\n", utility.SliceToString(network.NameserversV6))
+				utility.Printf("Nameservers IPv6: %s\n", utility.SliceToString(network.NameserversV6))
 			}
 		}
 	},

--- a/cmd/network/network_update.go
+++ b/cmd/network/network_update.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -48,7 +47,7 @@ var networkUpdateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Renamed the network called %s with ID %s to %s\n", utility.Green(oldNetwork.Label), utility.Green(network.ID), utility.Green(network.Label))
+			utility.Printf("Renamed the network called %s with ID %s to %s\n", utility.Green(oldNetwork.Label), utility.Green(network.ID), utility.Green(network.Label))
 		}
 	},
 }

--- a/cmd/network/vlan_connect.go
+++ b/cmd/network/vlan_connect.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -74,7 +73,7 @@ var networkConnectCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Created a network called %s with ID %s\n", utility.Green(network.Label), utility.Green(network.ID))
+			utility.Printf("Created a network called %s with ID %s\n", utility.Green(network.Label), utility.Green(network.ID))
 		}
 	},
 }

--- a/cmd/objectstore/objectstore_create.go
+++ b/cmd/objectstore/objectstore_create.go
@@ -107,10 +107,13 @@ var objectStoreCreateCmd = &cobra.Command{
 		if waitOS {
 			startTime := utility.StartTime()
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
-			s.Prefix = fmt.Sprintf("Creating an Object Store with maxSize %d, called %s... ", store.MaxSize, store.Name)
-			s.Start()
+			var s *spinner.Spinner
+			if !common.Quiet {
+				s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+				s.Writer = os.Stderr
+				s.Prefix = fmt.Sprintf("Creating an Object Store with maxSize %d, called %s... ", store.MaxSize, store.Name)
+				s.Start()
+			}
 
 			for stillCreating {
 				storeCheck, err := client.FindObjectStore(store.ID)
@@ -120,7 +123,9 @@ var objectStoreCreateCmd = &cobra.Command{
 				}
 				if storeCheck.Status == "ready" {
 					stillCreating = false
-					s.Stop()
+					if !common.Quiet {
+						s.Stop()
+					}
 				} else {
 					time.Sleep(2 * time.Second)
 				}
@@ -144,12 +149,12 @@ var objectStoreCreateCmd = &cobra.Command{
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			if waitOS {
-				fmt.Printf("Created Object Store %s in %s in %s\n", utility.Green(objectStore.Name), utility.Green(client.Region), executionTime)
-				fmt.Printf("Created default admin credentials, access key is %s, this will be deleted if the Object Store is deleted. ", utility.Green(objectStore.OwnerInfo.AccessKeyID))
-				fmt.Printf("To access the secret key run: civo objectstore credential secret --access-key=%s\n", utility.Green(objectStore.OwnerInfo.AccessKeyID))
+				utility.Printf("Created Object Store %s in %s in %s\n", utility.Green(objectStore.Name), utility.Green(client.Region), executionTime)
+				utility.Printf("Created default admin credentials, access key is %s, this will be deleted if the Object Store is deleted. ", utility.Green(objectStore.OwnerInfo.AccessKeyID))
+				utility.Printf("To access the secret key run: civo objectstore credential secret --access-key=%s\n", utility.Green(objectStore.OwnerInfo.AccessKeyID))
 			} else {
-				fmt.Printf("Creating Object Store %s in %s\n", utility.Green(objectStore.Name), utility.Green(client.Region))
-				fmt.Printf("To check the status of the Object Store run: civo objectstore show %s\n", utility.Green(objectStore.Name))
+				utility.Printf("Creating Object Store %s in %s\n", utility.Green(objectStore.Name), utility.Green(client.Region))
+				utility.Printf("To check the status of the Object Store run: civo objectstore show %s\n", utility.Green(objectStore.Name))
 			}
 		}
 	},

--- a/cmd/objectstore/objectstore_credential_create.go
+++ b/cmd/objectstore/objectstore_credential_create.go
@@ -57,10 +57,13 @@ var objectStoreCredentialCreateCmd = &cobra.Command{
 		if waitOS {
 			startTime := utility.StartTime()
 			stillCreating := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
-			s.Prefix = fmt.Sprintf("Creating an Object Store Credential with maxSize %d, called %s... ", credential.MaxSizeGB, credential.Name)
-			s.Start()
+			var s *spinner.Spinner
+			if !common.Quiet {
+				s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+				s.Writer = os.Stderr
+				s.Prefix = fmt.Sprintf("Creating an Object Store Credential with maxSize %d, called %s... ", credential.MaxSizeGB, credential.Name)
+				s.Start()
+			}
 
 			for stillCreating {
 				credCheck, err := client.FindObjectStoreCredential(credential.ID)
@@ -70,7 +73,9 @@ var objectStoreCredentialCreateCmd = &cobra.Command{
 				}
 				if credCheck.Status == "ready" {
 					stillCreating = false
-					s.Stop()
+					if !common.Quiet {
+						s.Stop()
+					}
 				} else {
 					time.Sleep(2 * time.Second)
 				}
@@ -93,9 +98,9 @@ var objectStoreCredentialCreateCmd = &cobra.Command{
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			if waitOS {
-				fmt.Printf("Created Object Store Credential %s in %s in %s\n", utility.Green(objectStoreCred.Name), utility.Green(client.Region), executionTime)
+				utility.Printf("Created Object Store Credential %s in %s in %s\n", utility.Green(objectStoreCred.Name), utility.Green(client.Region), executionTime)
 			} else {
-				fmt.Printf("Creating Object Store Credential %s in %s\n", utility.Green(objectStoreCred.Name), utility.Green(client.Region))
+				utility.Printf("Creating Object Store Credential %s in %s\n", utility.Green(objectStoreCred.Name), utility.Green(client.Region))
 			}
 		}
 	},

--- a/cmd/objectstore/objectstore_credential_delete.go
+++ b/cmd/objectstore/objectstore_credential_delete.go
@@ -2,7 +2,6 @@ package objectstore
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	pluralize "github.com/alejandrojnm/go-pluralize"
@@ -95,10 +94,10 @@ var objectStoreCredentialDeleteCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(objectStoreCredsList), "objectStoreCredential"), utility.Green(strings.Join(objectStoreCredsNameList, ", ")))
+				utility.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(objectStoreCredsList), "objectStoreCredential"), utility.Green(strings.Join(objectStoreCredsNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Println("Operation aborted")
 		}
 	},
 }

--- a/cmd/objectstore/objectstore_credential_export.go
+++ b/cmd/objectstore/objectstore_credential_export.go
@@ -1,7 +1,6 @@
 package objectstore
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -57,19 +56,19 @@ var objectStoreCredentialExportCmd = &cobra.Command{
 		}
 
 		if format == "env" {
-			fmt.Printf("# Tip: You can redirect output with (>> ~/.zshrc) to add these to Zsh's startup automatically\n")
-			fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", credential.AccessKeyID)
-			fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", credential.SecretAccessKeyID)
-			fmt.Printf("export AWS_DEFAULT_REGION=%s\n", client.Region)
-			fmt.Printf("export AWS_HOST=https://objectstore.%s.civo.com\n", strings.ToLower(client.Region))
+			utility.Printf("# Tip: You can redirect output with (>> ~/.zshrc) to add these to Zsh's startup automatically\n")
+			utility.Printf("export AWS_ACCESS_KEY_ID=%s\n", credential.AccessKeyID)
+			utility.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", credential.SecretAccessKeyID)
+			utility.Printf("export AWS_DEFAULT_REGION=%s\n", client.Region)
+			utility.Printf("export AWS_HOST=https://objectstore.%s.civo.com\n", strings.ToLower(client.Region))
 		} else if format == "s3cfg" {
-			fmt.Printf("# Tip: You can redirect output with (>> ~/.s3cfg) to automatically configure s3cmd\n")
-			fmt.Printf("[default]\n")
-			fmt.Printf("access_key = %s\n", credential.AccessKeyID)
-			fmt.Printf("secret_key = %s\n", credential.SecretAccessKeyID)
-			fmt.Printf("bucket_location = %s\n", client.Region)
-			fmt.Printf("host_base = objectstore.%s.civo.com\n", strings.ToLower(client.Region))
-			fmt.Printf("signature_v2 = True")
+			utility.Printf("# Tip: You can redirect output with (>> ~/.s3cfg) to automatically configure s3cmd\n")
+			utility.Printf("[default]\n")
+			utility.Printf("access_key = %s\n", credential.AccessKeyID)
+			utility.Printf("secret_key = %s\n", credential.SecretAccessKeyID)
+			utility.Printf("bucket_location = %s\n", client.Region)
+			utility.Printf("host_base = objectstore.%s.civo.com\n", strings.ToLower(client.Region))
+			utility.Printf("signature_v2 = True")
 		} else {
 			utility.Error("You must provide a valid format to export to. Supported formats are env and s3cfg. See --help for more information.")
 			os.Exit(1)

--- a/cmd/objectstore/objectstore_credential_secret.go
+++ b/cmd/objectstore/objectstore_credential_secret.go
@@ -1,7 +1,6 @@
 package objectstore
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -61,7 +60,7 @@ var objectStoreCredentialSecretCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Your secret key is: %s\n", utility.Green(credential.SecretAccessKeyID))
+			utility.Printf("Your secret key is: %s\n", utility.Green(credential.SecretAccessKeyID))
 		}
 	},
 }

--- a/cmd/objectstore/objectstore_credential_update.go
+++ b/cmd/objectstore/objectstore_credential_update.go
@@ -1,7 +1,6 @@
 package objectstore
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -63,7 +62,7 @@ var objectStoreCredentialUpdateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The Object Store Credential with ID %s is updated\n", utility.Green(cred.ID))
+			utility.Printf("The Object Store Credential with ID %s is updated\n", utility.Green(cred.ID))
 			os.Exit(0)
 		}
 	},

--- a/cmd/objectstore/objectstore_delete.go
+++ b/cmd/objectstore/objectstore_delete.go
@@ -2,7 +2,6 @@ package objectstore
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	pluralize "github.com/alejandrojnm/go-pluralize"
@@ -96,10 +95,10 @@ var objectStoreDeleteCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(objectStoreList), "objectStore"), utility.Green(strings.Join(objectStoreNameList, ", ")))
+				utility.Printf("The %s (%s) has been deleted\n", pluralize.Pluralize(len(objectStoreList), "objectStore"), utility.Green(strings.Join(objectStoreNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted")
+			utility.Println("Operation aborted")
 		}
 	},
 }

--- a/cmd/objectstore/objectstore_show.go
+++ b/cmd/objectstore/objectstore_show.go
@@ -58,7 +58,7 @@ var objectStoreShowCmd = &cobra.Command{
 		ow := utility.NewOutputWriter()
 
 		ow.StartLine()
-		fmt.Println()
+		utility.Println()
 		ow.AppendDataWithLabel("id", objectStore.ID, "ID")
 		ow.AppendDataWithLabel("name", objectStore.Name, "Name")
 		ow.AppendDataWithLabel("size", strconv.Itoa(objectStore.MaxSize), "Size")
@@ -75,7 +75,7 @@ var objectStoreShowCmd = &cobra.Command{
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
 			ow.WriteKeyValues()
-			fmt.Printf("To access the secret key run: civo objectstore credential secret --access-key=%s\n", utility.Green(creds.AccessKeyID))
+			utility.Printf("To access the secret key run: civo objectstore credential secret --access-key=%s\n", utility.Green(creds.AccessKeyID))
 		}
 	},
 }

--- a/cmd/objectstore/objectstore_update.go
+++ b/cmd/objectstore/objectstore_update.go
@@ -1,7 +1,6 @@
 package objectstore
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -58,7 +57,7 @@ var objectStoreUpdateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The Object Store with ID %s was updated to size: %d GB \n", utility.Green(objectStore.ID), bucketSize)
+			utility.Printf("The Object Store with ID %s was updated to size: %d GB \n", utility.Green(objectStore.ID), bucketSize)
 			os.Exit(0)
 		}
 	},

--- a/cmd/region/region_current.go
+++ b/cmd/region/region_current.go
@@ -1,7 +1,6 @@
 package region
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -32,7 +31,7 @@ var regionCurrentCmd = &cobra.Command{
 		}
 
 		if strings.ToLower(config.Current.Meta.DefaultRegion) == strings.ToLower(args[0]) {
-			fmt.Printf("You are already using that region: %s\n", utility.Red(args[0]))
+			utility.Printf("You are already using that region: %s\n", utility.Red(args[0]))
 			os.Exit(1)
 		}
 
@@ -46,7 +45,7 @@ var regionCurrentCmd = &cobra.Command{
 		}
 
 		if !validRegion {
-			fmt.Printf("The region you tried to set %s doesn't exist, please use 'civo region ls' to get the code of a valid region\n", utility.Red(args[0]))
+			utility.Printf("The region you tried to set %s doesn't exist, please use 'civo region ls' to get the code of a valid region\n", utility.Red(args[0]))
 			os.Exit(1)
 		}
 
@@ -58,7 +57,7 @@ var regionCurrentCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The default region was set to (%s) %s\n", regionName, utility.Green(args[0]))
+			utility.Printf("The default region was set to (%s) %s\n", regionName, utility.Green(args[0]))
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -137,6 +137,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&common.OutputFields, "fields", "f", "", "output fields for custom format output (use -h to determine fields)")
 	rootCmd.PersistentFlags().StringVarP(&common.OutputFormat, "output", "o", "human", "output format (json/human/custom)")
 	rootCmd.PersistentFlags().BoolVarP(&common.DefaultYes, "yes", "y", false, "Automatic yes to prompts; assume \"yes\" as answer to all prompts and run non-interactively")
+	rootCmd.PersistentFlags().BoolVarP(&common.Quiet, "quiet", "q", false, "Disables logging and run non-interactive, requires --yes flag wherever user prompts are required")
 	rootCmd.PersistentFlags().StringVarP(&common.RegionSet, "region", "", "", "Choose the region to connect to, if you use this option it will use it over the default region")
 	rootCmd.PersistentFlags().BoolVarP(&common.PrettySet, "pretty", "", false, "Print pretty the json output")
 	rootCmd.Flags().BoolVarP(&version, "version", "v", false, "Print the version of the CLI")

--- a/cmd/sshkey/ssh_key_create.go
+++ b/cmd/sshkey/ssh_key_create.go
@@ -1,7 +1,6 @@
 package sshkey
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -58,7 +57,7 @@ var sshKeyCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Created an SSH key called %s with ID %s\n", utility.Green(sshKey.Name), utility.Green(sshKey.ID))
+			utility.Printf("Created an SSH key called %s with ID %s\n", utility.Green(sshKey.Name), utility.Green(sshKey.ID))
 		}
 	},
 }

--- a/cmd/sshkey/ssh_key_find.go
+++ b/cmd/sshkey/ssh_key_find.go
@@ -1,11 +1,12 @@
 package sshkey
 
 import (
+	"os"
+
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var sshKeyFindCmd = &cobra.Command{

--- a/cmd/sshkey/ssh_key_remove.go
+++ b/cmd/sshkey/ssh_key_remove.go
@@ -83,10 +83,10 @@ var sshKeyRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The ssh %s (%s) has been deleted\n", pluralize.Pluralize(len(sshList), "key"), utility.Green(strings.Join(sshKeyNameList, ", ")))
+				utility.Printf("The ssh %s (%s) has been deleted\n", pluralize.Pluralize(len(sshList), "key"), utility.Green(strings.Join(sshKeyNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/sshkey/ssh_key_update.go
+++ b/cmd/sshkey/ssh_key_update.go
@@ -2,12 +2,13 @@ package sshkey
 
 import (
 	"errors"
+	"os"
+
 	"github.com/civo/civogo"
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var sshKeyUpdateCmd = &cobra.Command{

--- a/cmd/teams/teams_create.go
+++ b/cmd/teams/teams_create.go
@@ -1,7 +1,6 @@
 package teams
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -44,7 +43,7 @@ var teamsCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Created a team called %s with team ID %s\n", utility.Green(team.Name), utility.Green(team.ID))
+			utility.Printf("Created a team called %s with team ID %s\n", utility.Green(team.Name), utility.Green(team.ID))
 		}
 	},
 }

--- a/cmd/teams/teams_delete.go
+++ b/cmd/teams/teams_delete.go
@@ -82,10 +82,10 @@ var teamsDeleteCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The team %s(%s) has been deleted\n", pluralize.Pluralize(len(teamList), ""), utility.Green(strings.Join(teamNameList, ", ")))
+				utility.Printf("The team %s(%s) has been deleted\n", pluralize.Pluralize(len(teamList), ""), utility.Green(strings.Join(teamNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/teams/teams_rename.go
+++ b/cmd/teams/teams_rename.go
@@ -1,7 +1,6 @@
 package teams
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/cli/common"
@@ -45,7 +44,7 @@ var teamsRenameCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The team with ID %s was renamed to %s\n", utility.Green(team.ID), utility.Green(team.Name))
+			utility.Printf("The team with ID %s was renamed to %s\n", utility.Green(team.ID), utility.Green(team.Name))
 		}
 	},
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -49,7 +49,7 @@ var (
 
 			// no updates
 			if len(releases) == 0 {
-				fmt.Printf("%s\n", utility.Green("Your client is up to date"))
+				utility.Printf("%s\n", utility.Green("Your client is up to date"))
 				os.Exit(0)
 			}
 
@@ -73,7 +73,7 @@ var (
 						os.Exit(1)
 					}
 
-					fmt.Printf("Updated to %s\n", utility.Green(latest.Version))
+					utility.Printf("Updated to %s\n", utility.Green(latest.Version))
 
 				}
 			}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"fmt"
 	"runtime"
 
 	"github.com/civo/cli/common"
+	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
 )
 
@@ -27,18 +27,18 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			switch {
 			case verbose:
-				fmt.Printf(logo)
-				fmt.Printf("Client version: v%s\n", common.VersionCli)
-				fmt.Printf("Go version (client): %s\n", runtime.Version())
-				fmt.Printf("Build date (client): %s\n", common.DateCli)
-				fmt.Printf("Git commit (client): %s\n", common.CommitCli)
-				fmt.Printf("OS/Arch (client): %s/%s\n", runtime.GOOS, runtime.GOARCH)
+				utility.Printf(logo)
+				utility.Printf("Client version: v%s\n", common.VersionCli)
+				utility.Printf("Go version (client): %s\n", runtime.Version())
+				utility.Printf("Build date (client): %s\n", common.DateCli)
+				utility.Printf("Git commit (client): %s\n", common.CommitCli)
+				utility.Printf("OS/Arch (client): %s/%s\n", runtime.GOOS, runtime.GOARCH)
 				common.CheckVersionUpdate()
 			case quiet:
-				fmt.Printf("v%s\n", common.VersionCli)
+				utility.Printf("v%s\n", common.VersionCli)
 			default:
 				common.CheckVersionUpdate()
-				fmt.Printf("Civo CLI v%s\n", common.VersionCli)
+				utility.Printf("Civo CLI v%s\n", common.VersionCli)
 			}
 		},
 	}

--- a/cmd/volume/volume_attach.go
+++ b/cmd/volume/volume_attach.go
@@ -80,10 +80,13 @@ var volumeAttachCmd = &cobra.Command{
 		if waitVolumeAttach {
 
 			stillAttaching := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
-			s.Prefix = "Attaching volume to the instance... "
-			s.Start()
+			var s *spinner.Spinner
+			if !common.Quiet {
+				s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+				s.Writer = os.Stderr
+				s.Prefix = "Attaching volume to the instance... "
+				s.Start()
+			}
 
 			for stillAttaching {
 				volumeCheck, err := client.FindVolume(volume.ID)
@@ -93,7 +96,9 @@ var volumeAttachCmd = &cobra.Command{
 				}
 				if volumeCheck.Status == "attached" {
 					stillAttaching = false
-					s.Stop()
+					if !common.Quiet {
+						s.Stop()
+					}
 				} else {
 					time.Sleep(2 * time.Second)
 				}
@@ -102,7 +107,7 @@ var volumeAttachCmd = &cobra.Command{
 
 		if attachAtBoot {
 			out := utility.Yellow(fmt.Sprintf("To use the volume %s you need reboot the instance %s once the volume is in attaching/detaching state", volume.Name, instance.Hostname))
-			fmt.Println(out)
+			utility.Println(out)
 		}
 
 		ow := utility.NewOutputWriterWithMap(map[string]string{"id": volume.ID, "name": volume.Name})
@@ -113,7 +118,7 @@ var volumeAttachCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The volume called %s with ID %s was attached to the instance %s\n", utility.Green(volume.Name), utility.Green(volume.ID), utility.Green(instance.Hostname))
+			utility.Printf("The volume called %s with ID %s was attached to the instance %s\n", utility.Green(volume.Name), utility.Green(volume.ID), utility.Green(instance.Hostname))
 		}
 	},
 }

--- a/cmd/volume/volume_create.go
+++ b/cmd/volume/volume_create.go
@@ -1,7 +1,6 @@
 package volume
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/civo/civogo"
@@ -86,7 +85,7 @@ var volumeCreateCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("Created a volume called %s with ID %s\n", utility.Green(volume.Name), utility.Green(volume.ID))
+			utility.Printf("Created a volume called %s with ID %s\n", utility.Green(volume.Name), utility.Green(volume.ID))
 		}
 	},
 }

--- a/cmd/volume/volume_detach.go
+++ b/cmd/volume/volume_detach.go
@@ -1,7 +1,6 @@
 package volume
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -53,10 +52,13 @@ var volumeDetachCmd = &cobra.Command{
 		if waitVolumeDetach {
 
 			stillDetaching := true
-			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-			s.Writer = os.Stderr
-			s.Prefix = "Detaching the volume... "
-			s.Start()
+			var s *spinner.Spinner
+			if !common.Quiet {
+				s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+				s.Writer = os.Stderr
+				s.Prefix = "Detaching the volume... "
+				s.Start()
+			}
 
 			for stillDetaching {
 				volumeCheck, err := client.FindVolume(volume.ID)
@@ -66,7 +68,9 @@ var volumeDetachCmd = &cobra.Command{
 				}
 				if volumeCheck.Status == "available" {
 					stillDetaching = false
-					s.Stop()
+					if !common.Quiet {
+						s.Stop()
+					}
 				} else {
 					time.Sleep(2 * time.Second)
 				}
@@ -81,7 +85,7 @@ var volumeDetachCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The volume called %s with ID %s was detached\n", utility.Green(volume.Name), utility.Green(volume.ID))
+			utility.Printf("The volume called %s with ID %s was detached\n", utility.Green(volume.Name), utility.Green(volume.ID))
 		}
 	},
 }

--- a/cmd/volume/volume_remove.go
+++ b/cmd/volume/volume_remove.go
@@ -2,7 +2,6 @@ package volume
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 
@@ -98,10 +97,10 @@ var volumeRemoveCmd = &cobra.Command{
 			case "custom":
 				ow.WriteCustomOutput(common.OutputFields)
 			default:
-				fmt.Printf("The %s (%s) have been deleted\n", pluralize.Pluralize(len(volumesList), "volume"), utility.Green(strings.Join(volumeNameList, ", ")))
+				utility.Printf("The %s (%s) have been deleted\n", pluralize.Pluralize(len(volumesList), "volume"), utility.Green(strings.Join(volumeNameList, ", ")))
 			}
 		} else {
-			fmt.Println("Operation aborted.")
+			utility.Println("Operation aborted.")
 		}
 	},
 }

--- a/cmd/volume/volume_resize.go
+++ b/cmd/volume/volume_resize.go
@@ -1,7 +1,6 @@
 package volume
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
@@ -37,7 +36,7 @@ var volumeResizeCmd = &cobra.Command{
 		}
 
 		if newSizeGB < volume.SizeGigabytes {
-			fmt.Printf("Sorry, the volume size specified (%s) must be larger than the volume's current size (%s)\n", utility.Red(strconv.Itoa(newSizeGB)), utility.Green(strconv.Itoa(volume.SizeGigabytes)))
+			utility.Printf("Sorry, the volume size specified (%s) must be larger than the volume's current size (%s)\n", utility.Red(strconv.Itoa(newSizeGB)), utility.Green(strconv.Itoa(volume.SizeGigabytes)))
 			os.Exit(1)
 		}
 
@@ -55,7 +54,7 @@ var volumeResizeCmd = &cobra.Command{
 		case "custom":
 			ow.WriteCustomOutput(common.OutputFields)
 		default:
-			fmt.Printf("The volume called %s with ID %s was resized\n", utility.Green(volume.Name), utility.Green(volume.ID))
+			utility.Printf("The volume called %s with ID %s was resized\n", utility.Green(volume.Name), utility.Green(volume.ID))
 		}
 	},
 }

--- a/cmd/volumetype/volumetype.go
+++ b/cmd/volumetype/volumetype.go
@@ -2,6 +2,7 @@ package volumetype
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/volumetype/volumetype_list.go
+++ b/cmd/volumetype/volumetype_list.go
@@ -1,14 +1,14 @@
 package volumetype
 
 import (
-	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
-	"os"
-	"strconv"
-	"strings"
 )
 
 var volumetypesListCmd = &cobra.Command{
@@ -28,7 +28,7 @@ var volumetypesListCmd = &cobra.Command{
 		// Call ListVolumeTypes from SDK
 		volumeTypes, err := client.ListVolumeTypes()
 		if err != nil {
-			fmt.Printf("Error fetching volume types: %s\n", err)
+			utility.Printf("Error fetching volume types: %s\n", err)
 			return
 		}
 

--- a/common/common.go
+++ b/common/common.go
@@ -17,6 +17,8 @@ var (
 	RegionSet string
 	// DefaultYes : automatic yes to prompts; assume \"yes\" as answer to all prompts and run non-interactively
 	DefaultYes bool
+	// Quiet disables logging and run non-interactively; only throws errors and requires --yes flag wherever user prompts are required
+	Quiet bool
 	// PrettySet : Prints the json output in pretty format
 	PrettySet bool
 	// VersionCli is set from outside using ldflags

--- a/utility/check.go
+++ b/utility/check.go
@@ -26,7 +26,7 @@ func CheckOS() string {
 	case "linux":
 		returnValue = "linux"
 	default:
-		fmt.Printf("%s.\n", os)
+		Printf("%s.\n", os)
 	}
 
 	return returnValue

--- a/utility/confirmation.go
+++ b/utility/confirmation.go
@@ -3,6 +3,7 @@ package utility
 import (
 	"bufio"
 	"fmt"
+	"github.com/civo/cli/common"
 	"io"
 	"os"
 	"strings"
@@ -47,6 +48,14 @@ func AskForConfirm(message string) error {
 // a resource and then sends it through to AskForConfirm to
 // parses and verifies user input.
 func UserConfirmedDeletion(resourceType string, ignoringConfirmed bool, objectToDelete string) bool {
+	if common.Quiet {
+		if !ignoringConfirmed {
+			Warning("this is non-interactive mode. Please specify the -y flag in order to proceed")
+			return false
+		} else if ignoringConfirmed {
+			return true
+		}
+	}
 	if !ignoringConfirmed {
 		message := fmt.Sprintf("delete the %s %s", Green(objectToDelete), resourceType)
 		err := AskForConfirm(message)
@@ -62,6 +71,14 @@ func UserConfirmedDeletion(resourceType string, ignoringConfirmed bool, objectTo
 // a resource and then sends it through to AskForConfirm to
 // parses and verifies user input.
 func UserConfirmedUnassign(resourceType string, ignoringConfirmed bool, objectToDelete string) bool {
+	if common.Quiet {
+		if !ignoringConfirmed {
+			Warning("this is non-interactive mode. Please specify the -y flag in order to proceed")
+			return false
+		} else if ignoringConfirmed {
+			return true
+		}
+	}
 	if !ignoringConfirmed {
 		message := fmt.Sprintf("unassign %s %s from Civo resource", Green(objectToDelete), resourceType)
 		err := AskForConfirm(message)
@@ -77,6 +94,14 @@ func UserConfirmedUnassign(resourceType string, ignoringConfirmed bool, objectTo
 // a resource and then sends it through to AskForConfirm to
 // parses and verifies user input.
 func UserConfirmedRestore(resourceType string, ignoringConfirmed bool, objectToDelete string) bool {
+	if common.Quiet {
+		if !ignoringConfirmed {
+			Warning("this is non-interactive mode. Please specify the -y flag in order to proceed")
+			return false
+		} else if ignoringConfirmed {
+			return true
+		}
+	}
 	if !ignoringConfirmed {
 		message := fmt.Sprintf("restore db %s from %s backup", Green(resourceType), Green(objectToDelete))
 		err := AskForConfirm(message)
@@ -92,6 +117,14 @@ func UserConfirmedRestore(resourceType string, ignoringConfirmed bool, objectToD
 // and then sends it through to AskForConfirm to
 // parses and verifies user input.
 func UserConfirmedOverwrite(resourceType string, ignoringConfirmed bool) bool {
+	if common.Quiet {
+		if !ignoringConfirmed {
+			Warning("this is non-interactive mode. Please specify the -y flag in order to proceed")
+			return false
+		} else if ignoringConfirmed {
+			return true
+		}
+	}
 	if !ignoringConfirmed {
 		message := fmt.Sprintf("overwrite the %s", resourceType)
 		err := AskForConfirm(message)

--- a/utility/kubernetes.go
+++ b/utility/kubernetes.go
@@ -50,7 +50,7 @@ func mergeConfigs(localKubeconfigPath string, k3sconfig []byte, switchContext bo
 		return nil, writeErr
 	}
 
-	fmt.Printf("Merged with main kubernetes config: %s\n", Green(localKubeconfigPath))
+	Printf("Merged with main kubernetes config: %s\n", Green(localKubeconfigPath))
 
 	// Merge the two kubeconfigs and read the output into 'data'
 	osResult := CheckOS()
@@ -89,17 +89,17 @@ func mergeConfigs(localKubeconfigPath string, k3sconfig []byte, switchContext bo
 // Generates config files give the path to file: string and the data: []byte
 func writeConfig(path string, data []byte, suppressMessage bool, mergeConfigs bool, switchConfig bool, clusterName string) error {
 	if !suppressMessage {
-		fmt.Print("\nAccess your cluster with:\n")
+		Printf("\nAccess your cluster with:\n")
 		if mergeConfigs {
 			if !switchConfig {
-				fmt.Printf("kubectl config use-context %s\n", strings.ToLower(clusterName))
+				Printf("kubectl config use-context %s\n", strings.ToLower(clusterName))
 			}
-			fmt.Println("kubectl get node")
+			Println("kubectl get node")
 		} else {
 			if strings.Contains(path, ".kube") {
-				fmt.Print("kubectl get node\n")
+				Printf("kubectl get node\n")
 			} else {
-				fmt.Printf("KUBECONFIG=%s kubectl get node\n", path)
+				Printf("KUBECONFIG=%s kubectl get node\n", path)
 			}
 		}
 	}
@@ -141,7 +141,7 @@ func checkAppPlan(appList []civogo.KubernetesMarketplaceApplication, requested s
 	for i, app := range appList {
 		if strings.Contains(app.Name, appName) {
 			if foundIndex != -1 {
-				fmt.Printf("unable to find %s because there were multiple matches", appName)
+				Printf("unable to find %s because there were multiple matches", appName)
 			}
 			foundIndex = i
 		}
@@ -183,7 +183,7 @@ func RequestedSplit(appList []civogo.KubernetesMarketplaceApplication, requested
 	for i := range allsplit {
 		checkApp, err := checkAppPlan(appList, allsplit[i])
 		if err != nil {
-			fmt.Print(err)
+			Error("%s", err)
 		}
 
 		allApp = append(allApp, checkApp)

--- a/utility/logger.go
+++ b/utility/logger.go
@@ -1,0 +1,19 @@
+package utility
+
+import (
+	"fmt"
+
+	"github.com/civo/cli/common"
+)
+
+func Println(args ...interface{}) {
+	if !common.Quiet {
+		fmt.Println(args...)
+	}
+}
+
+func Printf(format string, args ...interface{}) {
+	if !common.Quiet {
+		fmt.Printf(format, args...)
+	}
+}

--- a/utility/output_writer.go
+++ b/utility/output_writer.go
@@ -6,13 +6,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/civo/cli/common"
-	"github.com/civo/cli/config"
 	"os"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/civo/cli/common"
+	"github.com/civo/cli/config"
 
 	"github.com/olekukonko/tablewriter"
 )
@@ -75,9 +76,9 @@ func (ow *OutputWriter) ToJSON(v interface{}, pretty bool) {
 	switch pretty {
 	case true:
 		result, _ := prettyprint(value)
-		fmt.Println(string(result))
+		Println(string(result))
 	default:
-		fmt.Println(string(value))
+		Println(string(value))
 	}
 }
 
@@ -131,16 +132,16 @@ func (ow *OutputWriter) WriteSingleObjectJSON(pretty bool) {
 
 	jsonString, err := json.Marshal(data)
 	if err != nil {
-		fmt.Println(err)
+		Println(err)
 		os.Exit(-1)
 	}
 
 	switch pretty {
 	case true:
 		result, _ := prettyprint(jsonString)
-		fmt.Println(string(result))
+		Println(string(result))
 	default:
-		fmt.Println(string(jsonString))
+		Println(string(jsonString))
 	}
 
 }
@@ -162,16 +163,16 @@ func (ow *OutputWriter) WriteMultipleObjectsJSON(pretty bool) {
 
 	jsonString, err := json.Marshal(data)
 	if err != nil {
-		fmt.Println(err)
+		Println(err)
 		os.Exit(-1)
 	}
 
 	switch pretty {
 	case true:
 		result, _ := prettyprint(jsonString)
-		fmt.Println(string(result))
+		Println(string(result))
 	default:
-		fmt.Println(string(jsonString))
+		Println(string(jsonString))
 	}
 
 }
@@ -191,7 +192,7 @@ func (ow *OutputWriter) WriteKeyValues() {
 	for i := range ow.Keys {
 		value := ow.Values[0][i]
 		label := ow.Labels[i]
-		fmt.Printf("%"+strconv.Itoa(longestLabelLength)+"s : %s\n", label, value)
+		Printf("%"+strconv.Itoa(longestLabelLength)+"s : %s\n", label, value)
 	}
 }
 
@@ -263,19 +264,19 @@ func (ow *OutputWriter) WriteCustomOutput(fields string) {
 		}
 		output = strings.Replace(output, "\\t", "\t", -1)
 		output = strings.Replace(output, "\\n", "\n", -1)
-		fmt.Println(output)
+		Println(output)
 	}
 }
 
 // WriteSubheader writes a centred heading line in to output
 func (ow *OutputWriter) WriteSubheader(label string) {
 	count := (72 - len(label) + 2) / 2
-	fmt.Println(strings.Repeat("-", count) + " " + label + " " + strings.Repeat("-", count))
+	Println(strings.Repeat("-", count) + " " + label + " " + strings.Repeat("-", count))
 }
 
 // WriteHeader WriteSubheader writes a centred heading line in to output
 func (ow *OutputWriter) WriteHeader(label string) {
-	fmt.Printf("%s:\n", label)
+	Printf("%s:\n", label)
 }
 
 func prettyprint(b []byte) ([]byte, error) {

--- a/utility/random.go
+++ b/utility/random.go
@@ -1,9 +1,10 @@
 package utility
 
 import (
-	"github.com/google/uuid"
 	"math/rand"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 var adjectives = [...]string{


### PR DESCRIPTION
Fixes https://github.com/civo/cli/issues/497

The PR is divided in two commits -
1. centralize the logging. Added a logger.go file in utility package which is being called throughout the codebase, replacing fmt.println() and fmt.printf()
2. Actual implementation on top of the first commit. 

Working demo ->
 
![Screenshot from 2025-02-18 03-33-48](https://github.com/user-attachments/assets/d23d5a80-46f8-4639-9bb6-5c11787c044b)
![Screenshot from 2025-02-18 03-34-03](https://github.com/user-attachments/assets/42e52ed1-1080-44de-a4b6-ba39fa5a5cc9)
![Screenshot from 2025-02-18 03-34-20](https://github.com/user-attachments/assets/cdf30973-b247-4142-923a-05a190e2f98d)
![Screenshot from 2025-02-18 03-46-39](https://github.com/user-attachments/assets/9bbda2e4-52ab-460a-a101-04f4b9cc646d)
