### PR TITLE
Update kubernetes_create.go

### DIFF
--- a/cmd/kubernetes/kubernetes_create.go
+++ b/cmd/kubernetes/kubernetes_create.go
@@ -232,7 +232,7 @@ var kubernetesCreateCmd = &cobra.Command{
 			stillCreating := true
 			s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 			s.Writer = os.Stderr
-			s.Prefix = fmt.Sprintf("Creating a %s node k3s cluster of %s instances called %s... ", strconv.Itoa(kubernetesCluster.NumTargetNode), kubernetesCluster.TargetNodeSize, kubernetesCluster.Name)
+      s.Prefix = fmt.Sprintf("Creating a %d node %s cluster of %s instances called %s... ",kubernetesCluster.NumTargetNode, clusterType, kubernetesCluster.TargetNodeSize, kubernetesCluster.Name)
 			s.Start()
 
 			for stillCreating {


### PR DESCRIPTION
Display correct cluster type during creation with --wait flag (#481)

Updated spinner to show the right cluster type dynamically (k3s→talos).