### PR TITLE
Update output_writer_test.go

### DIFF
--- a/utility/output_writer_test.go
+++ b/utility/output_writer_test.go
@@ -10,8 +10,8 @@ func TestWriteCustomOutput(t *testing.T) {
 	ow.WriteCustomOutput("B")
 }
 
-// TestExampleFWriteCustomOutput shows how to use the WriteCustomOutput function
-func TestExampleFWriteCustomOutput(t *testing.T) {
+// ExampleFWriteCustomOutput shows how to use the WriteCustomOutput function
+func ExampleFWriteCustomOutput() {
 	ow := NewOutputWriter()
 	// Write 3 lines and assert correct result
 	ow.StartLine()


### PR DESCRIPTION
fix: output writer test #434

Rename `TestExampleFWriteCustomOutput` to `ExampleFWriteCustomOutput` to follow Go's example function naming convention and remove unnecessary `t *testing.T`.