### PR TITLE
feat: add CLI commands to status and stop instance vnc sessions

### DIFF
--- a/cmd/instance/instance_vnc.go
+++ b/cmd/instance/instance_vnc.go
@@ -123,3 +123,7 @@ func waitEndpointReady(url string) error {
 		time.Sleep(7 * time.Second) // Wait for 7 seconds before the next attempt
 	}
 }
+func init() {
+	instanceVncCmd.AddCommand(statusCmd)
+	instanceVncCmd.AddCommand(stopCmd)
+}

--- a/cmd/instance/instance_vnc_status.go
+++ b/cmd/instance/instance_vnc_status.go
@@ -1,0 +1,93 @@
+package instance
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/civo/cli/config"
+	"github.com/civo/cli/utility"
+	"github.com/spf13/cobra"
+)
+
+type ActiveVNCResponse struct {
+	URI        string `json:"uri"`
+	Expiration string `json:"expiration"`
+}
+
+type InactiveVNCResponse struct {
+	Code   string `json:"code"`
+	Reason string `json:"reason"`
+}
+
+func GetVNCSession(baseURL, region, token, instanceinstanceID string) {
+	url := fmt.Sprintf("%s/v2/instances/%s/vnc?region=%s", baseURL, instanceinstanceID, region)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		utility.Error("Request creation error:%s", err)
+		return
+	}
+
+	req.Header.Set("Authorization", "bearer "+token)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+
+	if err != nil {
+		utility.Error("Request failed:%s", err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		utility.Error("Read body error:%s", err)
+		return
+	}
+
+	var vncResp ActiveVNCResponse
+	if err := json.Unmarshal(body, &vncResp); err == nil && vncResp.URI != "" {
+		utility.Info("🟢 VNC Session Active")
+		return
+
+	}
+	var errResp InactiveVNCResponse
+
+	if err := json.Unmarshal(body, &errResp); err == nil {
+		utility.Info("🔴 VNC Session Not Active")
+		return
+	}
+
+	fmt.Println("Unexpected response:", string(body))
+	utility.Error("Unexpected response:%s", string(body))
+
+}
+
+func fetchConfigStatus(instanceID, regionFlag string) {
+	config.ReadConfig()
+	baseURL := config.Current.Meta.URL
+	region := config.Current.Meta.DefaultRegion
+	token := config.DefaultAPIKey()
+	if regionFlag != "" {
+		region = regionFlag
+	}
+	GetVNCSession(baseURL, region, token, instanceID)
+}
+
+// Status command
+var statusCmd = &cobra.Command{
+	Use:   "status [param]",
+	Short: "Check if a VNC session is active",
+	Long:  `Use this command to check if a VNC session is currently running for a given instance. It takes one argument, instance id.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		param := args[0]
+		fetchConfigStatus(param, regionFlag)
+
+	},
+}
+
+func init() {
+	statusCmd.Flags().StringVarP(&regionFlag, "region", "r", "", "Region to use for the request")
+}

--- a/cmd/instance/instance_vnc_stop.go
+++ b/cmd/instance/instance_vnc_stop.go
@@ -1,0 +1,94 @@
+package instance
+
+import (
+	"fmt"
+	"net/http"
+
+	"encoding/json"
+
+	"github.com/civo/cli/config"
+	"github.com/civo/cli/utility"
+	"github.com/spf13/cobra"
+)
+
+type DeleteVNCResponse struct {
+	Result string `json:"result"`
+}
+
+type VNCAlreadyDeletedResponse struct {
+	Code   string `json:"code"`
+	Reason string `json:"reason"`
+}
+
+func DeleteVNCSession(baseURL, region, instanceinstanceID, token string) {
+	url := fmt.Sprintf("%s/v2/instances/%s/vnc?region=%s", baseURL, instanceinstanceID, region)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		utility.Error("Request creation error:%s", err)
+		return
+	}
+	req.Header.Set("Authorization", "bearer "+token)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		utility.Error("Request failed:%s", err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var successResp DeleteVNCResponse
+		if err := json.NewDecoder(resp.Body).Decode(&successResp); err != nil {
+			utility.Error("Error decoding success response:%s", err)
+			return
+		}
+		if successResp.Result == "ok" {
+			utility.Info("✅ VNC session successfully deleted.")
+		} else {
+			utility.Error("Unexpected success response:%s", err)
+		}
+	} else {
+		var errResp VNCAlreadyDeletedResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			utility.Error("Error decoding error response:%s", err)
+			return
+		}
+		if errResp.Code == "database_operation_find" {
+			utility.Info("⚠️ No active session found. Already deleted.")
+		} else {
+			utility.Error("Error: %s - %s\n", errResp.Code, errResp.Reason)
+		}
+
+	}
+
+}
+
+func fetchConfigStop(instanceID, regionFlag string) {
+	config.ReadConfig()
+	baseURL := config.Current.Meta.URL
+	region := config.Current.Meta.DefaultRegion
+	token := config.DefaultAPIKey()
+	if regionFlag != "" {
+		region = regionFlag
+	}
+
+	DeleteVNCSession(baseURL, region, instanceID, token)
+}
+
+var regionFlag string
+var stopCmd = &cobra.Command{
+	Use:   "stop [param]",
+	Short: "Stops an active VNC session before it expires",
+	Long:  ` Use this command to stop a VNC session before it ends on its own. It takes one argument, instance id. `,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		param := args[0]
+		fetchConfigStop(param, regionFlag)
+
+	},
+}
+
+func init() {
+	stopCmd.Flags().StringVarP(&regionFlag, "region", "r", "", "Region to use for the request")
+}


### PR DESCRIPTION
## feat: add CLI commands to manage instance console sessions

This update introduces new CLI commands to interact with instance VNC console sessions.

#### Added

- `civo instance console status <instance_id>`  
  Checks if a VNC session is currently active for the given instance.  

![status](https://github.com/user-attachments/assets/16433a43-d4d1-4e7a-942a-0c779a764996)

-  `civo instance console stop <instance_id>`  
  Terminates an active VNC session before its expiration.  
  
![stop](https://github.com/user-attachments/assets/f08e5294-9099-475f-ad30-32371f2a2654)


#### Region Handling

- If the `--region` flag is not specified, the default region will be used.

#### Examples


civo instance console status <instance_id> --region <region_name>

![Screenshot from 2025-05-12 01-28-53](https://github.com/user-attachments/assets/238098c8-dc4b-47cf-9500-4e7f995ca64f)


civo instance console stop <instance_id> --region <region_name>


![Screenshot from 2025-05-12 01-29-25](https://github.com/user-attachments/assets/200d8619-86f8-49db-bc11-8dd0a54a5e4d)


![WhatsAppVideo2025-05-12at1 08 58AM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/4c682dd6-dd3b-437e-994d-bf61b0f98ce1)
