### PR TITLE
support specifying volume-type when creating volumes

### DIFF
--- a/cmd/volume/volume.go
+++ b/cmd/volume/volume.go
@@ -32,6 +32,7 @@ func init() {
 
 	volumeCreateCmd.Flags().IntVarP(&createSizeGB, "size-gb", "s", 0, "The new size in GB (required)")
 	volumeCreateCmd.Flags().StringVarP(&networkVolumeID, "network", "t", "default", "The network name/ID where the volume will be created")
+	volumeCreateCmd.Flags().StringVarP(&volumeType, "volume-type", "v", "", "The type of the volume that will be created (as provided by 'civo volumetypes ls')")
 	volumeCreateCmd.MarkFlagRequired("size-gb")
 
 	volumeResizeCmd.Flags().IntVarP(&newSizeGB, "size-gb", "s", 0, "The new size in GB (required)")

--- a/cmd/volume/volume_create.go
+++ b/cmd/volume/volume_create.go
@@ -11,8 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var createSizeGB int
-var networkVolumeID string
+var (
+	createSizeGB    int
+	networkVolumeID string
+	volumeType      string
+)
 
 var volumeCreateCmd = &cobra.Command{
 	Use:     "create",
@@ -66,6 +69,10 @@ var volumeCreateCmd = &cobra.Command{
 			}
 
 			volumeConfig.NetworkID = network.ID
+		}
+
+		if volumeType != "" {
+			volumeConfig.VolumeType = volumeType
 		}
 
 		volume, err := client.NewVolume(volumeConfig)


### PR DESCRIPTION
Encrypted volume types are on the way! 

This PR adds support to the civo cli for specifying a volume-type when creating a new volume.