### PR TITLE
correctly visualise all the DB versions (not just the defaults)

### DIFF
--- a/cmd/database/database_version.go
+++ b/cmd/database/database_version.go
@@ -1,11 +1,13 @@
 package database
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/civo/cli/common"
 	"github.com/civo/cli/config"
 	"github.com/civo/cli/utility"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var dbVersionListCmd = &cobra.Command{
@@ -31,13 +33,18 @@ var dbVersionListCmd = &cobra.Command{
 			utility.Error("%s", err)
 			os.Exit(1)
 		}
+		fmt.Println(dbVersions)
 
 		ow := utility.NewOutputWriter()
 
+		// Iterate through each database type and all its versions
 		for dbName, versionDetails := range dbVersions {
-			ow.StartLine()
-			ow.AppendDataWithLabel("name", dbName, "Name")
-			ow.AppendDataWithLabel("version", versionDetails[0].SoftwareVersion, "version")
+			for _, version := range versionDetails {
+				ow.StartLine()
+				ow.AppendDataWithLabel("name", dbName, "Name")
+				ow.AppendDataWithLabel("version", version.SoftwareVersion, "Version")
+				ow.AppendDataWithLabel("default", fmt.Sprintf("%t", version.Default), "Default")
+			}
 		}
 
 		switch common.OutputFormat {

--- a/cmd/database/database_version.go
+++ b/cmd/database/database_version.go
@@ -33,7 +33,6 @@ var dbVersionListCmd = &cobra.Command{
 			utility.Error("%s", err)
 			os.Exit(1)
 		}
-		fmt.Println(dbVersions)
 
 		ow := utility.NewOutputWriter()
 


### PR DESCRIPTION
Before the change only defaults 
```
 $ civo database versions --region=lon1
+------------+---------+
| Name       | version |
+------------+---------+
| MySQL      |     8.0 |
+------------+---------+
| PostgreSQL |      14 |
+------------+---------+
```
after the change all the versions are shown:
```
$ civo database versions --region=lon1
+------------+---------+---------+
| Name       | Version | Default |
+------------+---------+---------+
| MySQL      |     8.0 | true    |
+------------+---------+---------+
| MySQL      |     8.4 | false   |
+------------+---------+---------+
| PostgreSQL |      14 | true    |
+------------+---------+---------+
| PostgreSQL |      15 | false   |
+------------+---------+---------+
| PostgreSQL |      16 | false   |
+------------+---------+---------+
```
| PostgreSQL |      17 | false   |
+------------+---------+---------+
```