### PR TITLE
Add /scheduled as backupID if `--scheduled` flag is found

### DIFF
--- a/cmd/database/database_backup.go
+++ b/cmd/database/database_backup.go
@@ -7,6 +7,7 @@ import (
 )
 
 var name, schedule, backupType string
+var scheduled bool
 
 // dbBackupCmd is the root command for the db backup subcommand
 var dbBackupCmd = &cobra.Command{
@@ -40,4 +41,7 @@ func init() {
 	// Update cmd options
 	dbBackupUpdateCmd.Flags().StringVarP(&name, "name", "n", "", "name of the database backup")
 	dbBackupUpdateCmd.Flags().StringVarP(&schedule, "schedule", "s", "", "schedule of the database backup in the form of cronjob")
+
+	// Delete cmd options
+	dbBackupDeleteCmd.Flags().BoolVar(&scheduled, "scheduled", false, "delete scheduled backups instead of manual backups")
 }

--- a/cmd/database/database_backup_delete.go
+++ b/cmd/database/database_backup_delete.go
@@ -20,9 +20,9 @@ var backupList []utility.ObjecteList
 var dbBackupDeleteCmd = &cobra.Command{
 	Use:     "delete",
 	Aliases: []string{"rm", "remove", "destroy"},
-	Short:   "Delete a manual database backup",
-	Example: "civo database backup delete <DATABASE-NAME/ID> <BACKUP-NAME/ID>",
-	Args:    cobra.MinimumNArgs(2),
+	Short:   "Delete a manual database backup or scheduled backups",
+	Example: "civo database backup delete <DATABASE-NAME/ID> <BACKUP-NAME/ID>\ncivo database backup delete <DATABASE-NAME/ID> --scheduled",
+	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		utility.EnsureCurrentRegion()
 
@@ -36,27 +36,31 @@ var dbBackupDeleteCmd = &cobra.Command{
 			client.Region = common.RegionSet
 		}
 
-		if len(args) == 2 {
-			bk, err := client.FindDatabaseBackup(args[0], args[1])
-			if err != nil {
-				if errors.Is(err, civogo.ZeroMatchesError) {
-					utility.Error("sorry there is no %s Database in your account", utility.Red(args[0]))
-					os.Exit(1)
-				}
-				if errors.Is(err, civogo.MultipleMatchesError) {
-					utility.Error("sorry we found more than one database with that name in your account")
-					os.Exit(1)
-				}
-			}
-			backupList = append(backupList, utility.ObjecteList{ID: bk.ID, Name: bk.Name})
+		if scheduled {
+			backupList = append(backupList, utility.ObjecteList{ID: "scheduled", Name: "scheduled backups"})
 		} else {
-			for idx, v := range args {
-				if idx == 0 {
-					continue
+			if len(args) == 2 {
+				bk, err := client.FindDatabaseBackup(args[0], args[1])
+				if err != nil {
+					if errors.Is(err, civogo.ZeroMatchesError) {
+						utility.Error("sorry there is no %s Database in your account", utility.Red(args[0]))
+						os.Exit(1)
+					}
+					if errors.Is(err, civogo.MultipleMatchesError) {
+						utility.Error("sorry we found more than one database with that name in your account")
+						os.Exit(1)
+					}
 				}
-				bk, err := client.FindDatabaseBackup(args[0], v)
-				if err == nil {
-					backupList = append(backupList, utility.ObjecteList{ID: bk.ID, Name: bk.Name})
+				backupList = append(backupList, utility.ObjecteList{ID: bk.ID, Name: bk.Name})
+			} else {
+				for idx, v := range args {
+					if idx == 0 {
+						continue
+					}
+					bk, err := client.FindDatabaseBackup(args[0], v)
+					if err == nil {
+						backupList = append(backupList, utility.ObjecteList{ID: bk.ID, Name: bk.Name})
+					}
 				}
 			}
 		}
@@ -69,12 +73,16 @@ var dbBackupDeleteCmd = &cobra.Command{
 		if utility.UserConfirmedDeletion(pluralize.Pluralize(len(backupList), "Database Backup"), common.DefaultYes, strings.Join(dbNameList, ", ")) {
 
 			for _, v := range backupList {
-				db, err := client.FindDatabaseBackup(args[0], v.ID)
-				if err != nil {
-					utility.Error("%s", err)
-					os.Exit(1)
+				dbId := v.ID
+				if !scheduled {
+					db, err := client.FindDatabaseBackup(args[0], dbId)
+					if err != nil {
+						utility.Error("%s", err)
+						os.Exit(1)
+					}
+					dbId = db.ID
 				}
-				_, err = client.DeleteDatabaseBackup(args[0], db.ID)
+				_, err = client.DeleteDatabaseBackup(args[0], dbId)
 				if err != nil {
 					utility.Error("Error deleting the Database backup: %s", err)
 					os.Exit(1)


### PR DESCRIPTION
We need to specify, as backupID the string "scheduled" as Databases can only have one scheduled backup at a time and they don't have an ID since they're bound to the CivoDatabase resource