### PR TITLE
fix: drop linux_386 support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,15 +7,9 @@ builds:
       - darwin
       - windows
     goarch:
-      - 386
       - amd64
       - arm
       - arm64
-    ignore:
-      - goos: darwin
-        goarch: 386
-      - goos: windows
-        goarch: 386
     ldflags:
       - -s -w -X  github.com/civo/cli/common.VersionCli={{.Version}} -X  github.com/civo/cli/common.CommitCli={{.Commit}} -X  github.com/civo/cli/common.DateCli={{.Date}}
 checksum:
@@ -54,15 +48,15 @@ dockers:
       - "civo/cli:{{ .Tag }}"
     dockerfile: docker/Dockerfile
 nfpms:
-  - file_name_template: '{{ .ProjectName }}_{{ .Arch }}'
-    homepage:  https://github.com/civo/cli
+  - file_name_template: "{{ .ProjectName }}_{{ .Arch }}"
+    homepage: https://github.com/civo/cli
     description: Our Command Line Interface (CLI) for interacting with your Civo resources
     maintainer: Alejandro J. Nuñez Madrazo <alejandro@civo.com>
     license: MIT
     vendor: Civo
     formats:
-    - deb
-    - rpm
+      - deb
+      - rpm
 # snapcrafts:
 #   - name_template: "{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 #     summary: Tool to handler all Civo cloud resource


### PR DESCRIPTION
We recently released a new version of the CLI that failed to be released because of an integer overflow error when building on `linux_386` architecture: https://github.com/civo/cli/issues/570